### PR TITLE
Give first-run Discover and blocked Findings a next click

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,16 +116,20 @@ smoke commands, read [Operations](docs/OPERATIONS.md).
 
 ## First use
 
-1. Open Studio and check **Readiness** for the control plane, catalog, storage,
-   Agent runtime, and credential posture.
+1. Open Studio. The default **Discover** page reports **System ready** source
+   health and a **Refresh catalogs** first step. The same refresh also lives on
+   **System overview**.
 2. Refresh anonymous catalogs. A refresh creates a new immutable corpus; it
    does not spend model budget or grant trading authority.
-3. Open the ontology / discovery workspace and inspect the standing campaigns.
-   Run a bounded campaign or issue against the retained corpus.
-4. Read the effect timeline, exact listing references, counterexamples, and
+3. If discovery is blocked (`credential unavailable`), open **Agent operations**
+   to inspect the existing Codex session. Stay on Discover to keep refreshing
+   catalogs without DeepSeek or Codex; **Explore next** is not the next click.
+4. After catalogs are in view, start a heuristic scan or inspect standing
+   campaigns against the retained corpus.
+5. Read the effect timeline, exact listing references, counterexamples, and
    token usage. An empty or falsified run is retained research evidence.
-5. Move only a grounded multi-listing hypothesis into independent review.
-6. Treat economic hints as routing signals until fresh books, fees, depth, and
+6. Move only a grounded multi-listing hypothesis into independent review.
+7. Treat economic hints as routing signals until fresh books, fees, depth, and
    the exact verifier all agree.
 
 The longer operator walkthrough is in [Studio](docs/STUDIO.md).

--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -66,6 +66,13 @@ import {
 import { buildOpportunityFrontier } from "@/data/opportunity-frontier";
 import { useDiscoveryExecutionCapability } from "@/data/discovery-execution";
 import {
+  discoverFirstStep,
+  discoverSpendAction,
+  findingsPrimaryAction,
+  inspirationEmptyState,
+  isCredentialBlockedDispatch,
+} from "@/data/first-operator-next-step";
+import {
   useStandingRouteWorkspace,
   type StandingRouteState,
   type StandingRouteUsage,
@@ -6945,8 +6952,13 @@ function RealCandidatePreflightView() {
   );
 }
 
-function MarketArchaeologistView() {
+function MarketArchaeologistView({
+  onNavigate,
+}: {
+  onNavigate: (view: View) => void;
+}) {
   const studioProjection = useStudioProjection();
+  const catalogObservation = studioProjection.ai.catalogObservation;
   const corpus =
     studioProjection.ai.marketCorpus ?? EMPTY_MARKET_CORPUS;
   const catalogRefreshScheduler =
@@ -7050,6 +7062,9 @@ function MarketArchaeologistView() {
   const [deepRetryLeaseId, setDeepRetryLeaseId] = useState<string | null>(null);
   const [issueAction, setIssueAction] = useState<string | null>(null);
   const [issueDiagnostic, setIssueDiagnostic] = useState<string | null>(null);
+  const [refreshStatus, setRefreshStatus] = useState<
+    "IDLE" | "RUNNING" | "READY" | "DEGRADED" | "FAILED"
+  >("IDLE");
   const [newIssueTitle, setNewIssueTitle] = useState("");
   const [newIssueQuestion, setNewIssueQuestion] = useState("");
   const [newIssueLens, setNewIssueLens] = useState<SearchIssue["lens"]>("EQUIVALENCE");
@@ -7058,6 +7073,17 @@ function MarketArchaeologistView() {
   const discoveryCapability = discoveryExecution.data?.capability;
   const discoveryRuntime = discoveryExecution.data?.runtime;
   const discoveryModel = discoveryExecution.data?.model;
+  const discoveryBlocked = isCredentialBlockedDispatch(
+    discoveryCapability?.dispatchEligibility,
+    discoveryCapability?.diagnostic ?? discoveryExecution.diagnostic,
+  );
+  const firstStep = discoverFirstStep({
+    healthySourceCount: catalogObservation.healthySourceCount,
+    sourceCount: catalogObservation.sourceCount,
+    listingCount: catalogObservation.listingCount,
+  });
+  const spendAction = discoverSpendAction(discoveryBlocked);
+  const emptyInspiration = inspirationEmptyState(discoveryBlocked);
   const currentLensRecords = scheduler.records.filter(
     (record) => record.lease.snapshotIdentity === corpus.snapshotIdentity,
   );
@@ -7090,6 +7116,15 @@ function MarketArchaeologistView() {
       setLeaseDiagnostic(
         error instanceof Error ? error.message : "search lease failed",
       );
+    }
+  }
+
+  async function refreshCatalog(): Promise<void> {
+    setRefreshStatus("RUNNING");
+    try {
+      setRefreshStatus(await requestCatalogRefresh());
+    } catch {
+      setRefreshStatus("FAILED");
     }
   }
 
@@ -7207,23 +7242,30 @@ function MarketArchaeologistView() {
             {discoveryExecution.preflightBusy ? <RefreshCw className="is-spinning" size={13} /> : <ShieldCheck size={13} />}
             {discoveryCapability?.observation == null ? "Preflight" : "Recheck"}
           </Button>
-          <Button
-            disabled={
-              corpus.listingCount === 0 ||
-              nextLens === undefined ||
-              scheduler.status === "RUNNING" ||
-              leaseStatus === "RUNNING" ||
-              discoveryCapability?.dispatchEligibility !== "ELIGIBLE"
-            }
-            onClick={() => void runLease()}
-          >
-            {leaseStatus === "RUNNING" ? (
-              <RefreshCw className="is-spinning" size={13} />
-            ) : (
-              <Sparkles size={13} />
-            )}
-            {leaseStatus === "RUNNING" ? "Exploring…" : "Start heuristic scan"}
-          </Button>
+          {spendAction.kind === "OPEN_AGENT_OPERATIONS" ? (
+            <Button onClick={() => onNavigate("agents")}>
+              <Bot size={13} />
+              {spendAction.label}
+            </Button>
+          ) : (
+            <Button
+              disabled={
+                corpus.listingCount === 0 ||
+                nextLens === undefined ||
+                scheduler.status === "RUNNING" ||
+                leaseStatus === "RUNNING" ||
+                discoveryCapability?.dispatchEligibility !== "ELIGIBLE"
+              }
+              onClick={() => void runLease()}
+            >
+              {leaseStatus === "RUNNING" ? (
+                <RefreshCw className="is-spinning" size={13} />
+              ) : (
+                <Sparkles size={13} />
+              )}
+              {leaseStatus === "RUNNING" ? "Exploring…" : spendAction.label}
+            </Button>
+          )}
         </div>
       </div>
 
@@ -7233,6 +7275,29 @@ function MarketArchaeologistView() {
           {discoveryExecution.diagnostic ?? `Discovery is blocked before model spend: ${discoveryCapability?.diagnostic ?? "run a capability preflight"}`}
         </div>
       )}
+
+      <section className="first-operator-step" aria-label="First step">
+        <div>
+          <span className="eyebrow">{firstStep.title}</span>
+          <strong>{firstStep.sourceHealthLabel}</strong>
+          <p>{firstStep.body}</p>
+        </div>
+        <div className="first-operator-step-actions">
+          <Button
+            disabled={refreshStatus === "RUNNING"}
+            onClick={() => void refreshCatalog()}
+          >
+            <RefreshCw size={13} />
+            {refreshStatus === "RUNNING"
+              ? "Refreshing…"
+              : refreshStatus === "FAILED"
+                ? "Retry refresh"
+                : refreshStatus === "READY" || refreshStatus === "DEGRADED"
+                  ? "Catalogs refreshed"
+                  : firstStep.primaryLabel}
+          </Button>
+        </div>
+      </section>
 
       <div className="radar-summary-grid archaeology-summary-grid">
         <Metric
@@ -7344,8 +7409,8 @@ function MarketArchaeologistView() {
               <div className="inspiration-empty">
                 <Sparkles size={18} />
                 <div>
-                  <strong>No useful detours yet</strong>
-                  <p>When a heuristic scan finds a grounded relation outside its assignment, it appears here instead of being forced into a claim.</p>
+                  <strong>{emptyInspiration.title}</strong>
+                  <p>{emptyInspiration.body}</p>
                 </div>
               </div>
             ) : (
@@ -11388,8 +11453,10 @@ function StandingRouteMemory({ revision }: { revision: string }) {
 
 function ScoutInboxView({
   onOpenReview,
+  onNavigate,
 }: {
   onOpenReview: (proposalIds: readonly string[]) => void;
+  onNavigate: (view: View) => void;
 }) {
   const studioProjection = useStudioProjection();
   const scheduler = studioProjection.ai.searchLeaseScheduler ?? EMPTY_SEARCH_LEASE_SCHEDULER;
@@ -11430,6 +11497,10 @@ function ScoutInboxView({
   const discoveryCapability = discoveryExecution.data?.capability;
   const discoveryRuntime = discoveryExecution.data?.runtime;
   const discoveryModel = discoveryExecution.data?.model;
+  const findingsAction = findingsPrimaryAction({
+    dispatchEligibility: discoveryCapability?.dispatchEligibility,
+    diagnostic: discoveryCapability?.diagnostic ?? discoveryExecution.diagnostic,
+  });
   const liveContextEligible =
     catalogMode === "VERIFIED_FIXTURES" ||
     selectedVenueIds.every(
@@ -11545,34 +11616,44 @@ function ScoutInboxView({
             {discoveryExecution.preflightBusy ? <RefreshCw className="is-spinning" size={13} /> : <ShieldCheck size={13} />}
             {discoveryCapability?.observation == null ? "Preflight" : "Recheck"}
           </Button>
-          <Button
-            disabled={
-              scheduler.status === "RUNNING" ||
-              explorationStatus === "RUNNING" ||
-              discoveryCapability?.dispatchEligibility !== "ELIGIBLE"
-            }
-            onClick={() => void exploreNext()}
-          >
-            {explorationStatus === "RUNNING" ? (
-              <RefreshCw className="is-spinning" size={13} />
-            ) : (
-              <Sparkles size={13} />
-            )}
-            {explorationStatus === "RUNNING"
-              ? "Exploring…"
-              : explorationStatus === "RESTORED"
-                ? "Latest scan restored"
-                : explorationStatus === "FAILED"
-                  ? "Retry exploration"
-                  : "Explore next"}
-          </Button>
+          {findingsAction.kind === "OPEN_AGENT_OPERATIONS" ? (
+            <Button onClick={() => onNavigate("agents")}>
+              <Bot size={13} />
+              {findingsAction.label}
+            </Button>
+          ) : (
+            <Button
+              disabled={
+                scheduler.status === "RUNNING" ||
+                explorationStatus === "RUNNING" ||
+                discoveryCapability?.dispatchEligibility !== "ELIGIBLE"
+              }
+              onClick={() => void exploreNext()}
+            >
+              {explorationStatus === "RUNNING" ? (
+                <RefreshCw className="is-spinning" size={13} />
+              ) : (
+                <Sparkles size={13} />
+              )}
+              {explorationStatus === "RUNNING"
+                ? "Exploring…"
+                : explorationStatus === "RESTORED"
+                  ? "Latest scan restored"
+                  : explorationStatus === "FAILED"
+                    ? "Retry exploration"
+                    : findingsAction.label}
+            </Button>
+          )}
         </div>
       </div>
 
       {(discoveryExecution.diagnostic !== null || discoveryCapability?.dispatchEligibility === "BLOCKED") && (
         <div className="inline-alert" role="status">
           <CircleOff size={14} />
-          {discoveryExecution.diagnostic ?? `Discovery is blocked before model spend: ${discoveryCapability?.diagnostic ?? "run a capability preflight"}`}
+          <div>
+            <p>{discoveryExecution.diagnostic ?? `Discovery is blocked before model spend: ${discoveryCapability?.diagnostic ?? "run a capability preflight"}`}</p>
+            {findingsAction.helper !== "" && <p>{findingsAction.helper}</p>}
+          </div>
         </div>
       )}
 
@@ -14073,7 +14154,9 @@ function StudioShell({ projectionSync }: { projectionSync: ProjectionSyncState }
         <main>
           {view === "overview" && <Overview onInspect={setOpportunity} />}
           {view === "agents" && <AgentOperationsView />}
-          {view === "archaeologist" && <MarketArchaeologistView />}
+          {view === "archaeologist" && (
+            <MarketArchaeologistView onNavigate={(nextView) => navigate(nextView)} />
+          )}
           {view === "lifecycle" && (
             <OpportunityLifecycleView
               focusedProposalIds={focusedProposalIds}
@@ -14085,6 +14168,7 @@ function StudioShell({ projectionSync }: { projectionSync: ProjectionSyncState }
           {view === "scouts" && (
             <ScoutInboxView
               onOpenReview={(proposalIds) => navigate("lifecycle", proposalIds)}
+              onNavigate={(nextView) => navigate(nextView)}
             />
           )}
           {view === "budgets" && (

--- a/apps/studio/src/data/first-operator-next-step.test.ts
+++ b/apps/studio/src/data/first-operator-next-step.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  catalogHealthLabel,
+  discoverFirstStep,
+  discoverSpendAction,
+  findingsPrimaryAction,
+  inspirationEmptyState,
+  isCredentialBlockedDispatch,
+} from "./first-operator-next-step";
+
+const emptyCatalog = Object.freeze({
+  healthySourceCount: 0,
+  sourceCount: 7,
+  listingCount: 0,
+});
+
+const populatedCatalog = Object.freeze({
+  healthySourceCount: 6,
+  sourceCount: 7,
+  listingCount: 600,
+});
+
+describe("first-operator next step", () => {
+  it("uses the sidebar System ready words for source health", () => {
+    expect(catalogHealthLabel(populatedCatalog)).toBe(
+      "System ready · 6/7 sources · 600 markets",
+    );
+  });
+
+  it("makes Refresh catalogs the Discover first step on an empty desk", () => {
+    const step = discoverFirstStep(emptyCatalog);
+    expect(step.title).toBe("First step");
+    expect(step.primaryAction).toBe("REFRESH_CATALOGS");
+    expect(step.primaryLabel).toBe("Refresh catalogs");
+    expect(step.sourceHealthLabel).toContain("0/7 sources");
+    expect(step.body).toMatch(/Refresh anonymous catalogs/);
+    expect(step.body).not.toMatch(/Readiness/);
+  });
+
+  it("keeps Refresh catalogs visible after catalogs already exist", () => {
+    const step = discoverFirstStep(populatedCatalog);
+    expect(step.primaryLabel).toBe("Refresh catalogs");
+    expect(step.sourceHealthLabel).toBe(
+      "System ready · 6/7 sources · 600 markets",
+    );
+    expect(step.body).toMatch(/Refresh catalogs/);
+    expect(step.body).toMatch(/heuristic scan/);
+  });
+
+  it("tells an empty inspiration inbox what to do next", () => {
+    expect(inspirationEmptyState(false)).toEqual({
+      title: "No useful detours yet",
+      body: "Refresh catalogs on this page first, then start a heuristic scan. Cross-lens inspirations appear here after a scan finds a grounded relation outside its assignment.",
+    });
+    expect(inspirationEmptyState(true).body).toMatch(/Agent operations/);
+    expect(inspirationEmptyState(true).body).not.toMatch(/Readiness/);
+  });
+
+  it("treats BLOCKED and credential-unavailable diagnostics as blocked dispatch", () => {
+    expect(isCredentialBlockedDispatch("BLOCKED", "runtime unavailable")).toBe(true);
+    expect(isCredentialBlockedDispatch("ELIGIBLE", "credential unavailable")).toBe(false);
+    expect(isCredentialBlockedDispatch(undefined, "Discovery is blocked before model spend: credential unavailable")).toBe(true);
+    expect(isCredentialBlockedDispatch("ELIGIBLE", "ready")).toBe(false);
+    expect(isCredentialBlockedDispatch(undefined, null)).toBe(false);
+  });
+
+  it("replaces Explore next as the Findings primary when dispatch is blocked", () => {
+    const action = findingsPrimaryAction({
+      dispatchEligibility: "BLOCKED",
+      diagnostic: "credential unavailable",
+    });
+    expect(action.exploreNextPrimary).toBe(false);
+    expect(action.kind).toBe("OPEN_AGENT_OPERATIONS");
+    expect(action.label).toBe("Open Agent operations");
+    expect(action.helper).toMatch(/Codex OAuth session/);
+    expect(action.helper).toMatch(/Discover/);
+    expect(action.helper).not.toMatch(/Readiness/);
+  });
+
+  it("keeps Explore next as the Findings primary when dispatch is eligible", () => {
+    const action = findingsPrimaryAction({
+      dispatchEligibility: "ELIGIBLE",
+      diagnostic: "ready",
+    });
+    expect(action).toEqual({
+      kind: "EXPLORE_NEXT",
+      label: "Explore next",
+      helper: "",
+      exploreNextPrimary: true,
+    });
+  });
+
+  it("points Discover spend at Agent operations when credentials are blocked", () => {
+    expect(discoverSpendAction(true)).toEqual({
+      kind: "OPEN_AGENT_OPERATIONS",
+      label: "Open Agent operations",
+    });
+    expect(discoverSpendAction(false)).toEqual({
+      kind: "HEURISTIC_SCAN",
+      label: "Start heuristic scan",
+    });
+  });
+});

--- a/apps/studio/src/data/first-operator-next-step.ts
+++ b/apps/studio/src/data/first-operator-next-step.ts
@@ -1,0 +1,91 @@
+export type DiscoveryDispatchEligibility = "ELIGIBLE" | "BLOCKED";
+
+export type CatalogHealth = Readonly<{
+  healthySourceCount: number;
+  sourceCount: number;
+  listingCount: number;
+}>;
+
+export function catalogHealthLabel(health: CatalogHealth): string {
+  return `System ready · ${health.healthySourceCount}/${health.sourceCount} sources · ${health.listingCount} markets`;
+}
+
+export function isCredentialBlockedDispatch(
+  eligibility: DiscoveryDispatchEligibility | undefined,
+  diagnostic: string | null | undefined,
+): boolean {
+  if (eligibility === "ELIGIBLE") return false;
+  if (eligibility === "BLOCKED") return true;
+  return (diagnostic ?? "").toLowerCase().includes("credential unavailable");
+}
+
+export function discoverFirstStep(health: CatalogHealth): Readonly<{
+  title: "First step";
+  sourceHealthLabel: string;
+  body: string;
+  primaryAction: "REFRESH_CATALOGS";
+  primaryLabel: "Refresh catalogs";
+}> {
+  return Object.freeze({
+    title: "First step",
+    sourceHealthLabel: catalogHealthLabel(health),
+    body: health.listingCount === 0
+      ? "Refresh anonymous catalogs to see which sources are healthy. This does not spend model budget or grant trading authority."
+      : "Anonymous catalogs are already in view. Refresh catalogs to take a new immutable corpus, then start a heuristic scan. Refresh does not spend model budget.",
+    primaryAction: "REFRESH_CATALOGS",
+    primaryLabel: "Refresh catalogs",
+  });
+}
+
+export function inspirationEmptyState(blocked: boolean): Readonly<{
+  title: "No useful detours yet";
+  body: string;
+}> {
+  return Object.freeze({
+    title: "No useful detours yet",
+    body: blocked
+      ? "Refresh catalogs here without a provider key, or open Agent operations to inspect the existing Codex session. Model spend stays blocked until that session is available."
+      : "Refresh catalogs on this page first, then start a heuristic scan. Cross-lens inspirations appear here after a scan finds a grounded relation outside its assignment.",
+  });
+}
+
+export function discoverSpendAction(blocked: boolean): Readonly<{
+  kind: "HEURISTIC_SCAN" | "OPEN_AGENT_OPERATIONS";
+  label: string;
+}> {
+  return blocked
+    ? Object.freeze({
+        kind: "OPEN_AGENT_OPERATIONS",
+        label: "Open Agent operations",
+      })
+    : Object.freeze({
+        kind: "HEURISTIC_SCAN",
+        label: "Start heuristic scan",
+      });
+}
+
+export function findingsPrimaryAction(input: Readonly<{
+  dispatchEligibility: DiscoveryDispatchEligibility | undefined;
+  diagnostic: string | null | undefined;
+}>): Readonly<{
+  kind: "EXPLORE_NEXT" | "OPEN_AGENT_OPERATIONS";
+  label: string;
+  helper: string;
+  exploreNextPrimary: boolean;
+}> {
+  if (isCredentialBlockedDispatch(input.dispatchEligibility, input.diagnostic)) {
+    return Object.freeze({
+      kind: "OPEN_AGENT_OPERATIONS",
+      label: "Open Agent operations",
+      helper:
+        "Attach the existing Codex OAuth session in Agent operations, or stay on Discover to refresh catalogs without DeepSeek or Codex.",
+      exploreNextPrimary: false,
+    });
+  }
+  return Object.freeze({
+    kind: "EXPLORE_NEXT",
+    label: "Explore next",
+    helper: "",
+    exploreNextPrimary: true,
+  });
+}

--- a/apps/studio/src/index.css
+++ b/apps/studio/src/index.css
@@ -2344,6 +2344,38 @@ main {
   margin: 3px 0 0;
 }
 
+.first-operator-step {
+  align-items: flex-start;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  display: flex;
+  gap: 18px;
+  justify-content: space-between;
+  margin: 0 0 18px;
+  padding: 16px;
+}
+
+.first-operator-step strong {
+  display: block;
+  font-size: 14px;
+  margin-top: 2px;
+}
+
+.first-operator-step p {
+  color: var(--muted-foreground);
+  font-size: 13px;
+  line-height: 1.5;
+  margin: 4px 0 0;
+}
+
+.first-operator-step-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
 .inspiration-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -7598,6 +7630,11 @@ footer span:first-child {
 
   .archaeology-heading-badges {
     justify-content: flex-start;
+  }
+
+  .first-operator-step {
+    align-items: stretch;
+    flex-direction: column;
   }
 
   .archaeology-pipeline {

--- a/apps/studio/src/product-shell.css
+++ b/apps/studio/src/product-shell.css
@@ -2584,7 +2584,8 @@ footer {
   .scout-heading,
   .ai-rack-header,
   .ai-rack-footer,
-  .ai-runtime-panel-heading {
+  .ai-runtime-panel-heading,
+  .first-operator-step {
     align-items: stretch;
     flex-direction: column;
   }
@@ -3595,13 +3596,55 @@ footer {
 
 .inline-alert {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 8px;
   border: 1px solid color-mix(in srgb, var(--destructive) 45%, var(--border));
   border-radius: 10px;
   padding: 10px 12px;
   color: var(--destructive);
   font-size: 13px;
+}
+
+.inline-alert p {
+  margin: 0;
+}
+
+.inline-alert p + p {
+  color: var(--muted-foreground);
+  margin-top: 4px;
+}
+
+.first-operator-step {
+  align-items: flex-start;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  display: flex;
+  gap: 18px;
+  justify-content: space-between;
+  margin: 12px 0 16px;
+  padding: 16px;
+}
+
+.first-operator-step strong {
+  display: block;
+  font-size: 14px;
+  margin-top: 2px;
+}
+
+.first-operator-step p {
+  color: var(--muted-foreground);
+  font-size: 13px;
+  line-height: 1.5;
+  margin: 4px 0 0;
+}
+
+.first-operator-step-actions {
+  display: flex;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
 }
 
 @media (max-width: 900px) {
@@ -4732,7 +4775,8 @@ footer {
   .scout-heading,
   .ai-rack-header,
   .ai-rack-footer,
-  .ai-runtime-panel-heading {
+  .ai-runtime-panel-heading,
+  .first-operator-step {
     align-items: stretch;
     flex-direction: column;
   }

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -150,8 +150,10 @@ Then verify in Studio:
   printed by the process.
 - **Studio says offline:** check `http://127.0.0.1:4100/health` and the control
   plane terminal output.
-- **Model unavailable:** inspect the runtime/credential posture in Readiness.
-  The system should fail visibly; do not assume a hidden fallback.
+- **Model unavailable:** inspect the runtime/credential posture in **Agent
+  operations**. The Discover sidebar reports **System ready** source health, not
+  a Readiness panel. The system should fail visibly; do not assume a hidden
+  fallback.
 - **DeepSeek setting appears ignored:** the SQLite configuration saved after
   first startup overrides environment seed values. Change it in Studio or use
   a fresh operational store intentionally.

--- a/docs/STUDIO.md
+++ b/docs/STUDIO.md
@@ -289,8 +289,10 @@ dashboard together. Vite starts at `127.0.0.1:5173` and automatically advances
 to the next free port. The dashboard uses a same-origin development proxy for
 the control plane; always follow the URL printed by Vite.
 
-On first use, check readiness and storage posture before refreshing catalogs or
-starting a campaign. Catalog refresh is anonymous and does not call a model.
-Agent work begins only through an explicit action or an enabled durable
-scheduler. The selected provider, runtime capability, model, reasoning effort,
-campaign state, and usage lineage remain visible in Studio.
+On first use, open **Discover**. Check **System ready** source health, then
+**Refresh catalogs**. Catalog refresh is anonymous and does not call a model.
+If discovery dispatch is blocked, open **Agent operations** for the existing
+Codex session; do not expect **Explore next** to be the next click. Agent work
+begins only through an explicit action or an enabled durable scheduler. The
+selected provider, runtime capability, model, reasoning effort, campaign state,
+and usage lineage remain visible in Studio.


### PR DESCRIPTION
Fixes #1
Fixes #2

## Thesis

A first operator landing on Discover cannot tell whether the empty desk is waiting for a click or stuck. Findings already fail-closes model spend when the Codex session is missing, then still sells **Explore next** as the green primary. The next click already exists: anonymous **Refresh catalogs** on the research desk, and **Agent operations** for the existing Codex session. This change makes those words the first-run path without adding a new product surface or OAuth wizard.

## What changed

- **Discover** (`?view=discover`) now presents a first step with **System ready · N/M sources · K markets** and a **Refresh catalogs** action. Empty-state copy says what to do next instead of only “No useful detours yet.”
- When discovery dispatch is `BLOCKED` / credential unavailable, **Findings** no longer keeps **Explore next** as the green primary. The primary becomes **Open Agent operations**. Discover does the same for the spend button, replacing **Start heuristic scan**.
- README First use, `docs/STUDIO.md`, and the Operations troubleshooting note now use the same words as the UI: **System ready**, **Discover**, **Refresh catalogs**, **Agent operations**. They no longer tell the operator to check a **Readiness** panel that is not on the default page.
- Focused Studio tests cover the copy and CTA selection in `apps/studio/src/data/first-operator-next-step.test.ts`.

Authority is unchanged: catalog refresh remains observe-only, `liveExecutionEnabled` / value movement stay false, and no campaign or model spend is auto-started.

## Out of scope

- Issue #3 (Live data / Live markets wording) and issue #4 (6/7 source hover).
- New OAuth/credential product, DeepSeek setup, or live execution.

## How to check

```bash
pnpm studio
```

Then:

1. Open `http://127.0.0.1:5173/?view=discover` (or the Vite-printed port). The default page should show **First step**, **System ready** source health, and **Refresh catalogs**. The empty inspiration inbox should tell the operator to refresh catalogs, then scan.
2. Confirm **Refresh catalogs** is anonymous: it does not require DeepSeek or a Codex session and does not spend model budget.
3. Open `?view=findings` with discovery blocked (`credential unavailable`, `In-process · gpt-5.6-terra · UNVERIFIED`). The fail-closed banner should remain. The green primary should be **Open Agent operations**, not a disabled **Explore next**.
4. Confirm **Research mode · Analysis only · no execution** is unchanged. Do not click Scout / Pi spend paths if you are only checking first-run copy.

```bash
pnpm --filter @pmh/studio test
```