### PR TITLE
Rename Live data / Live markets so they cannot be read as trading

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -1113,7 +1113,7 @@ invalidation; the 2.27 MB bounded view is built on demand, shared per revision,
 and served with an exact ETag. On retained local state, a matching conditional
 read returned 304 with zero bytes in 0.000789 seconds, and the observed idle
 control-plane sample fell from the old 52–55% projection-fanout workload to
-0.2%. Studio retains its last good view and reports Live data, Updating, or
+0.2%. Studio retains its last good view and reports SSE connected, Updating, or
 Reconnecting instead of silently replacing megabytes of state.
 
 The product bottleneck has moved from discovery volume to opportunity delivery.

--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -4053,7 +4053,7 @@ function Topbar({
         ? `${Math.floor(staleAge / 60_000)}m old`
         : `${Math.floor(staleAge / 3_600_000)}h old`;
   const syncLabel = projectionSync.status === "LIVE"
-    ? "Live data"
+    ? "SSE connected"
     : projectionSync.status === "STALE_REVALIDATING"
       ? `Last known · ${staleAgeLabel} · revalidating`
     : projectionSync.status === "REFRESHING"
@@ -6030,7 +6030,7 @@ function Overview({
             {studioProjection.identity.stateHash.slice(0, 22)}…
           </code>
           <div>
-            <Badge variant="muted">Live data</Badge>
+            <Badge variant="muted">Observed catalog</Badge>
             <span>{studioProjection.identity.mode} · {studioProjection.identity.view}</span>
           </div>
         </div>
@@ -6038,7 +6038,7 @@ function Overview({
 
       <section className="metric-grid" aria-label="System metrics">
         <Metric
-          label="Live markets"
+          label="Catalog listings"
           value={`${catalogObservation.listingCount}`}
           detail="current anonymous catalog"
         />
@@ -7236,7 +7236,7 @@ function MarketArchaeologistView() {
 
       <div className="radar-summary-grid archaeology-summary-grid">
         <Metric
-          label="Live markets"
+          label="Catalog listings"
           value={`${corpus.listingCount}`}
           detail="public contracts in view"
         />

--- a/plans/studio-invalidation-stream.md
+++ b/plans/studio-invalidation-stream.md
@@ -92,7 +92,7 @@ scheduling for the same event loop as evidence accumulates.
   invalidation-only fanout and a per-revision cache, an idle sample fell to
   0.2%; projection cost is now paid on operator demand instead of every effect.
 - Studio retains the last good projection, allows at most one request in flight,
-  collapses invalidations into one follow-up read, and exposes Live data,
+  collapses invalidations into one follow-up read, and exposes SSE connected,
   Updating, Connecting, or Reconnecting in the product shell.
 - Focused server/stream tests passed 28/28 and Studio projection tests passed
   11/11. Full workspace type checks, all 576 tests, and the production build


### PR DESCRIPTION
Fixes #3

## Problem

Studio showed **Live data** when projection sync was `LIVE` (SSE connected) and **Live markets** for the anonymous catalog listing count. Those labels sit next to **Research mode · Analysis only · no execution** and the footer that opportunities are research evidence, not orders. A first user can still read “live” as a live book / tradable feed. This is a safety misread, not a missing feature.

## What changed

Copy only. The badges still measure the same things, and authority is unchanged.

| Surface | Was | Now | Still measures |
| --- | --- | --- | --- |
| Top bar sync badge (`LIVE`) | Live data | **SSE connected** | Projection SSE connected |
| Overview snapshot badge | Live data | **Observed catalog** | Current catalog snapshot identity |
| Overview metric | Live markets | **Catalog listings** | Anonymous catalog listing count |
| Discover metric | Live markets | **Catalog listings** | Public contracts currently in view |

Plan notes that taught the old top-bar words now say **SSE connected**.

Kept: **Research mode · Analysis only · no execution**. No orders, signing, funds, OAuth, campaigns, or model spend. `liveExecutionEnabled` is untouched.

## Independent of #1 / #2

This branch starts from current `main` (`c1f63ce`). It does not include Discover first-step or Findings CTA work from `cursor/first-operator-next-step-044b` / PR #5.

Out of scope: issues #1, #2, and #4.

## How to check in Studio

```bash
pnpm studio
```

Open the Vite-printed URL (usually `http://127.0.0.1:5173/`):

1. With the control plane up, the top bar should show **SSE connected** (or Updating / Connecting / Reconnecting). It should not say **Live data**.
2. Overview (`?view=overview` or the default page) should show **Observed catalog** on the snapshot card and **Catalog listings** for the listing-count metric, not **Live markets**.
3. Discover (`?view=discover`) should use **Catalog listings** for the same kind of count.
4. Confirm **Research mode · Analysis only · no execution** is unchanged in the sidebar, and the footer still says displayed opportunities are research evidence, not orders.

```bash
pnpm --filter @pmh/studio test
```

Existing Studio tests do not assert the old strings. This PR does not add product behavior, so no new test file was required.