### PR TITLE
Name the missing catalog source from sidebar System ready

### DIFF
--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -70,6 +70,7 @@ import {
   type StandingRouteState,
   type StandingRouteUsage,
 } from "@/data/standing-routes";
+import { describeSidebarCatalogStatus } from "@/lib/sidebar-catalog-status";
 import { cn } from "@/lib/utils";
 import {
   parseWorkspaceRoute,
@@ -3891,18 +3892,37 @@ async function requestCandidateWatchRefresh(): Promise<"READY" | "DEGRADED"> {
 
 function SidebarStatus() {
   const studioProjection = useStudioProjection();
-  const observation = studioProjection.ai.catalogObservation;
+  const status = describeSidebarCatalogStatus(
+    studioProjection.ai.catalogObservation,
+  );
   return (
-    <div className="sidebar-status">
-      <span className="sidebar-status-dot" />
-      <div>
-        <strong>System ready</strong>
-        <span>
-          {observation.healthySourceCount}/{observation.sourceCount} sources ·{" "}
-          {observation.listingCount} markets
-        </span>
+    <details className={cn("sidebar-status", `is-${status.tone}`)}>
+      <summary className="sidebar-status-summary" title={status.hoverLabel}>
+        <span className="sidebar-status-dot" />
+        <div>
+          <strong>{status.heading}</strong>
+          <span>{status.countLabel}</span>
+        </div>
+      </summary>
+      <div className="sidebar-status-detail">
+        {status.unhealthySources.length === 0 ? (
+          <p>All catalog sources are current.</p>
+        ) : (
+          <ul>
+            {status.unhealthySources.map((source) => (
+              <li key={source.venueId}>
+                <strong>{source.venueId}</strong>
+                <span>{source.statusLabel}</span>
+                {source.diagnostic !== null && (
+                  <span>{source.diagnostic}</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+        <p>{status.refreshHint}</p>
       </div>
-    </div>
+    </details>
   );
 }
 

--- a/apps/studio/src/index.css
+++ b/apps/studio/src/index.css
@@ -297,6 +297,25 @@ pre,
   padding: 14px 8px 2px;
 }
 
+details.sidebar-status {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+}
+
+.sidebar-status-summary {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 10px;
+  list-style: none;
+  cursor: pointer;
+}
+
+.sidebar-status-summary::-webkit-details-marker {
+  display: none;
+}
+
 .sidebar-status-dot {
   width: 8px;
   height: 8px;
@@ -305,7 +324,17 @@ pre,
   background: var(--primary);
 }
 
-.sidebar-status > div {
+.sidebar-status.is-degraded .sidebar-status-dot {
+  background: var(--warning);
+}
+
+.sidebar-status.is-idle .sidebar-status-dot,
+.sidebar-status.is-refreshing .sidebar-status-dot {
+  background: var(--muted-foreground);
+}
+
+.sidebar-status > div,
+.sidebar-status-summary > div {
   display: flex;
   min-width: 0;
   flex-direction: column;
@@ -314,12 +343,47 @@ pre,
 
 .sidebar-status strong { font-size: 13px; }
 
-.sidebar-status span:last-child {
+.sidebar-status > div > span:last-child,
+.sidebar-status-summary span:last-child {
   overflow: hidden;
   color: var(--muted-foreground);
   font-size: 12px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.sidebar-status-detail {
+  min-width: 0;
+  padding-left: 18px;
+}
+
+.sidebar-status-detail p,
+.sidebar-status-detail li {
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.sidebar-status-detail ul {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0 0 8px;
+  padding: 0;
+  list-style: none;
+}
+
+.sidebar-status-detail li {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.sidebar-status-detail li strong {
+  color: var(--foreground);
+  font-size: 12px;
 }
 
 .venue-pulse {

--- a/apps/studio/src/lib/sidebar-catalog-status.test.ts
+++ b/apps/studio/src/lib/sidebar-catalog-status.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import {
+  describeSidebarCatalogStatus,
+  type SidebarCatalogObservationInput,
+  type SidebarCatalogSourceInput,
+} from "./sidebar-catalog-status.js";
+
+function source(
+  venueId: string,
+  status: SidebarCatalogSourceInput["status"],
+  diagnostic: string | null = null,
+): SidebarCatalogSourceInput {
+  return { venueId, status, diagnostic };
+}
+
+function observation(
+  patch: Partial<SidebarCatalogObservationInput> &
+    Pick<SidebarCatalogObservationInput, "status" | "sources">,
+): SidebarCatalogObservationInput {
+  const healthySourceCount = patch.sources.filter(
+    (item) => item.status === "CURRENT",
+  ).length;
+  return {
+    healthySourceCount: patch.healthySourceCount ?? healthySourceCount,
+    sourceCount: patch.sourceCount ?? patch.sources.length,
+    listingCount: patch.listingCount ?? 600,
+    ...patch,
+  };
+}
+
+describe("sidebar catalog status", () => {
+  it("keeps the ready heading when every source is current", () => {
+    const status = describeSidebarCatalogStatus(
+      observation({
+        status: "READY",
+        listingCount: 600,
+        sources: [
+          source("polymarket-global", "CURRENT"),
+          source("kalshi", "CURRENT"),
+        ],
+      }),
+    );
+
+    expect(status).toMatchObject({
+      heading: "System ready",
+      tone: "ready",
+      countLabel: "2/2 sources · 600 markets",
+      refreshUseful: false,
+      refreshHint: "Catalog refresh is not required for source health.",
+      unhealthySources: [],
+    });
+    expect(status.hoverLabel).toContain("All catalog sources are current.");
+    expect(status.hoverLabel).toContain("2/2 sources · 600 markets");
+  });
+
+  it("names the missing source and says refresh may help", () => {
+    const status = describeSidebarCatalogStatus(
+      observation({
+        status: "DEGRADED",
+        listingCount: 600,
+        sources: [
+          source("polymarket-global", "CURRENT"),
+          source("polymarket-us", "CURRENT"),
+          source("kalshi", "CURRENT"),
+          source("gemini-predictions", "FAILED", "timed out"),
+          source("opinion", "CURRENT"),
+          source("myriad", "CURRENT"),
+          source("limitless", "CURRENT"),
+        ],
+      }),
+    );
+
+    expect(status.heading).toBe("Sources degraded");
+    expect(status.tone).toBe("degraded");
+    expect(status.countLabel).toBe("6/7 sources · 600 markets");
+    expect(status.unhealthySources).toEqual([
+      {
+        venueId: "gemini-predictions",
+        status: "FAILED",
+        statusLabel: "failed",
+        diagnostic: "timed out",
+      },
+    ]);
+    expect(status.refreshUseful).toBe(true);
+    expect(status.refreshHint).toBe(
+      "Catalog refresh on System overview may recover this source.",
+    );
+    expect(status.hoverLabel).toContain(
+      "Unhealthy: gemini-predictions (failed).",
+    );
+    expect(status.hoverLabel).toContain(
+      "Catalog refresh on System overview may recover this source.",
+    );
+  });
+
+  it("names every unhealthy source when more than one is down", () => {
+    const status = describeSidebarCatalogStatus(
+      observation({
+        status: "DEGRADED",
+        listingCount: 412,
+        sources: [
+          source("kalshi", "STALE_AFTER_FAILURE", "502"),
+          source("limitless", "NEVER_REFRESHED"),
+          source("opinion", "CURRENT"),
+        ],
+      }),
+    );
+
+    expect(status.unhealthySources.map((item) => item.venueId)).toEqual([
+      "kalshi",
+      "limitless",
+    ]);
+    expect(status.refreshHint).toBe(
+      "Catalog refresh on System overview may recover these sources.",
+    );
+    expect(status.hoverLabel).toContain(
+      "Unhealthy: kalshi (stale after failure), limitless (never refreshed).",
+    );
+  });
+
+  it("treats an idle catalog as refresh-next without claiming readiness", () => {
+    const status = describeSidebarCatalogStatus(
+      observation({
+        status: "IDLE",
+        listingCount: 0,
+        sources: [
+          source("polymarket-global", "NEVER_REFRESHED"),
+          source("kalshi", "NEVER_REFRESHED"),
+        ],
+      }),
+    );
+
+    expect(status).toMatchObject({
+      heading: "Catalog idle",
+      tone: "idle",
+      countLabel: "0/2 sources · 0 markets",
+      refreshUseful: true,
+      refreshHint: "Catalog refresh on System overview is the next step.",
+    });
+    expect(status.hoverLabel).not.toContain("System ready");
+  });
+
+  it("does not recommend another refresh while one is already running", () => {
+    const status = describeSidebarCatalogStatus(
+      observation({
+        status: "REFRESHING",
+        listingCount: 600,
+        sources: [
+          source("kalshi", "CURRENT"),
+          source("gemini-predictions", "FAILED", "connection reset"),
+        ],
+      }),
+    );
+
+    expect(status).toMatchObject({
+      heading: "Refreshing catalogs",
+      tone: "refreshing",
+      refreshUseful: false,
+      refreshHint: "Catalog refresh is already running.",
+    });
+    expect(status.unhealthySources[0]?.venueId).toBe("gemini-predictions");
+  });
+});

--- a/apps/studio/src/lib/sidebar-catalog-status.ts
+++ b/apps/studio/src/lib/sidebar-catalog-status.ts
@@ -1,0 +1,163 @@
+export type SidebarCatalogSourceStatus =
+  | "NEVER_REFRESHED"
+  | "CURRENT"
+  | "STALE_AFTER_FAILURE"
+  | "FAILED";
+
+export type SidebarCatalogObservationStatus =
+  | "IDLE"
+  | "REFRESHING"
+  | "READY"
+  | "DEGRADED";
+
+export type SidebarCatalogSourceInput = Readonly<{
+  venueId: string;
+  status: SidebarCatalogSourceStatus;
+  diagnostic: string | null;
+}>;
+
+export type SidebarCatalogObservationInput = Readonly<{
+  status: SidebarCatalogObservationStatus;
+  healthySourceCount: number;
+  sourceCount: number;
+  listingCount: number;
+  sources: readonly SidebarCatalogSourceInput[];
+}>;
+
+export type SidebarCatalogTone = "ready" | "degraded" | "refreshing" | "idle";
+
+export type SidebarUnhealthySource = Readonly<{
+  venueId: string;
+  status: Exclude<SidebarCatalogSourceStatus, "CURRENT">;
+  statusLabel: string;
+  diagnostic: string | null;
+}>;
+
+export type SidebarCatalogStatus = Readonly<{
+  heading: string;
+  tone: SidebarCatalogTone;
+  sourceCount: number;
+  healthySourceCount: number;
+  listingCount: number;
+  countLabel: string;
+  hoverLabel: string;
+  unhealthySources: readonly SidebarUnhealthySource[];
+  refreshUseful: boolean;
+  refreshHint: string;
+}>;
+
+const SOURCE_STATUS_LABEL: Readonly<
+  Record<Exclude<SidebarCatalogSourceStatus, "CURRENT">, string>
+> = Object.freeze({
+  NEVER_REFRESHED: "never refreshed",
+  STALE_AFTER_FAILURE: "stale after failure",
+  FAILED: "failed",
+});
+
+export function sourceStatusLabel(
+  status: Exclude<SidebarCatalogSourceStatus, "CURRENT">,
+): string {
+  return SOURCE_STATUS_LABEL[status];
+}
+
+export function describeSidebarCatalogStatus(
+  observation: SidebarCatalogObservationInput,
+): SidebarCatalogStatus {
+  const unhealthySources = Object.freeze(
+    observation.sources.flatMap((source): SidebarUnhealthySource[] => {
+      if (source.status === "CURRENT") {
+        return [];
+      }
+      return [
+        Object.freeze({
+          venueId: source.venueId,
+          status: source.status,
+          statusLabel: sourceStatusLabel(source.status),
+          diagnostic: source.diagnostic,
+        }),
+      ];
+    }),
+  );
+  const tone = catalogTone(observation.status);
+  const heading = catalogHeading(observation.status);
+  const countLabel =
+    `${observation.healthySourceCount}/${observation.sourceCount} sources · ` +
+    `${observation.listingCount} markets`;
+  const refreshUseful =
+    observation.status !== "REFRESHING" &&
+    (observation.status === "IDLE" || unhealthySources.length > 0);
+  const refreshHint = catalogRefreshHint({
+    status: observation.status,
+    unhealthyCount: unhealthySources.length,
+    refreshUseful,
+  });
+  const hoverLabel = [
+    countLabel,
+    unhealthySources.length === 0
+      ? "All catalog sources are current."
+      : `Unhealthy: ${unhealthySources
+          .map((source) => `${source.venueId} (${source.statusLabel})`)
+          .join(", ")}.`,
+    refreshHint,
+  ].join(" ");
+
+  return Object.freeze({
+    heading,
+    tone,
+    sourceCount: observation.sourceCount,
+    healthySourceCount: observation.healthySourceCount,
+    listingCount: observation.listingCount,
+    countLabel,
+    hoverLabel,
+    unhealthySources,
+    refreshUseful,
+    refreshHint,
+  });
+}
+
+function catalogTone(
+  status: SidebarCatalogObservationStatus,
+): SidebarCatalogTone {
+  if (status === "READY") {
+    return "ready";
+  }
+  if (status === "REFRESHING") {
+    return "refreshing";
+  }
+  if (status === "IDLE") {
+    return "idle";
+  }
+  return "degraded";
+}
+
+function catalogHeading(status: SidebarCatalogObservationStatus): string {
+  if (status === "REFRESHING") {
+    return "Refreshing catalogs";
+  }
+  if (status === "IDLE") {
+    return "Catalog idle";
+  }
+  if (status === "DEGRADED") {
+    return "Sources degraded";
+  }
+  return "System ready";
+}
+
+function catalogRefreshHint(input: {
+  status: SidebarCatalogObservationStatus;
+  unhealthyCount: number;
+  refreshUseful: boolean;
+}): string {
+  if (input.status === "REFRESHING") {
+    return "Catalog refresh is already running.";
+  }
+  if (input.status === "IDLE") {
+    return "Catalog refresh on System overview is the next step.";
+  }
+  if (!input.refreshUseful) {
+    return "Catalog refresh is not required for source health.";
+  }
+  return input.unhealthyCount === 1
+    ? "Catalog refresh on System overview may recover this source."
+    : "Catalog refresh on System overview may recover these sources.";
+}

--- a/apps/studio/src/product-shell.css
+++ b/apps/studio/src/product-shell.css
@@ -772,8 +772,19 @@ pre,
   font-weight: 550;
 }
 
-.sidebar-status span:last-child,
+.sidebar-status > div > span:last-child,
+.sidebar-status-summary span:last-child,
 .authority-note span {
+  color: #737c79;
+  font-size: 12px;
+}
+
+.sidebar-status-detail {
+  padding-left: 18px;
+}
+
+.sidebar-status-detail p,
+.sidebar-status-detail li {
   color: #737c79;
   font-size: 12px;
 }
@@ -4182,10 +4193,17 @@ body {
   font-weight: 550;
 }
 
-.sidebar-status span:last-child,
+.sidebar-status > div > span:last-child,
+.sidebar-status-summary span:last-child,
 .authority-note span {
   color: #6f7874;
   font-size: 13px;
+}
+
+.sidebar-status-detail p,
+.sidebar-status-detail li {
+  color: #6f7874;
+  font-size: 12px;
 }
 
 .topbar {


### PR DESCRIPTION
Fixes #4.

## Problem

Sidebar **System ready** showed `6/7 sources · 600 mark…` with a green dot. The listing count was truncated, and clicking the row did not say which venue was unhealthy or whether a catalog refresh would help. That information lived only on System overview, so green + truncation read as fully healthy.

## Change

The existing sidebar catalog status is now hoverable and expandable. It still uses the current `catalogObservation` projection (`healthySourceCount`, `sourceCount`, `listingCount`, and per-source `status` / `diagnostic`). No new page, OAuth wizard, or execution surface.

- Hover (native title) names unhealthy venue IDs and whether refresh is a useful next step.
- Click to expand lists those sources with status (and diagnostic when present).
- A 6/7 desk no longer claims **System ready** with a green pip: the heading becomes **Sources degraded** and the pip turns amber.
- Idle / already-refreshing catalogs say that refresh is the next step or already running.

Authority is unchanged: observe-only catalog health, no credentials, no signing, no funds.

This PR is independent of first-run Discover/Findings work (#5) and live-copy wording (#6). Those strings were left alone.

## How to check

1. Open Studio against current main with a degraded catalog (for example 6/7 sources, one `FAILED` or `NEVER_REFRESHED`).
2. In the sidebar, hover **Sources degraded**: the tooltip should name the missing venue and say that catalog refresh on System overview may recover it.
3. Click the status: the expanded panel should list the same venue without leaving the sidebar.
4. With every source `CURRENT`, the row should still say **System ready**, and expand/hover should say all sources are current and refresh is not required for health.
5. Confirm Discover / Findings CTAs and Live data wording are unchanged.

## Out of scope

Issues #1, #2, and #3. Live trading, campaigns, and model spend.