### PR TITLE
Rename Radar copy that reads as a live feed or profit

### DIFF
--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -10871,7 +10871,7 @@ function OpportunityRadarView() {
               ? "Sources refreshed"
               : refreshStatus === "FAILED"
                 ? "Retry refresh"
-                : "Refresh live radar"}
+                : "Refresh catalogs"}
         </Button>
       </div>
 
@@ -10889,7 +10889,7 @@ function OpportunityRadarView() {
         <Metric
           label="Candidate pairs"
           value={`${radar.candidateCount}`}
-          detail={`${radar.candidates.filter((candidate) => candidate.indicativeEconomics.status === "POSITIVE_GROSS_HINT").length} positive gross hints`}
+          detail={`${radar.candidates.filter((candidate) => candidate.indicativeEconomics.status === "POSITIVE_GROSS_HINT").length} catalog-price overlap hints · not executable`}
         />
         <Metric
           label="Scout triage"


### PR DESCRIPTION
Fixes #8
Fixes #9

## Problem

`?view=radar` (Opportunity radar) showed **Refresh live radar** on the primary outline button and **N positive gross hints** on the Candidate pairs summary metric. The page already says similarity is not profit or a certificate, and the sidebar still says **Analysis only · no execution**. Those two strings can still be read as a live tradable scan and a P&amp;L count.

This is the same safety-misread class as #3 / PR #6, on Radar only.

## What changed

Copy only in `OpportunityRadarView`. The button still calls anonymous catalog/source refresh. The metric still counts `POSITIVE_GROSS_HINT` pairs. Pair-row bigint floors (`N bps before fees/depth`) are unchanged. Authority is unchanged.

| Surface | Was | Now | Still does |
| --- | --- | --- | --- |
| Radar heading button (idle) | Refresh live radar | **Refresh catalogs** | `requestCatalogRefresh()` — anonymous catalogs, not books/orders |
| Candidate pairs metric detail | N positive gross hints | **N catalog-price overlap hints · not executable** | Count of `POSITIVE_GROSS_HINT` pairs |

Kept in-flight **Refreshing sources…**, **Sources refreshed**, and **Retry refresh**. Kept the heading caveat (similarity is not profit or a certificate), pair-row `N bps before fees/depth`, and the Radar footer that candidates cannot compute executable profit or grant execution authority.

No algorithm change, no auto-triage, no scout spend, no orders, signing, funds, or credentials. `liveExecutionEnabled` is untouched.

## Independent of #1–#4 / PRs #5–#7

This branch starts from current `main` (`c1f63ce`). It does not include `cursor/first-operator-next-step-044b` (PR #5), `cursor/live-copy-safety-5b41` (PR #6), or `cursor/sidebar-missing-source-d431` (PR #7).

Out of scope: issues #1–#4 and Radar triage / scout spend.

## How to check in Studio

```bash
pnpm studio
```

Open the Vite-printed URL at **`?view=radar`**:

1. The primary outline button should say **Refresh catalogs**, not **Refresh live radar**. While running it should still say **Refreshing sources…**.
2. The **Candidate pairs** card detail should say **N catalog-price overlap hints · not executable**, not **positive gross hints** or **positive gross**.
3. Pair rows should still show the bigint floor as **N bps before fees/depth** when the projection has one.
4. Confirm the heading still says similarity is not profit or a certificate, and the Radar footer still says candidates cannot compute executable profit or grant execution authority.
5. Confirm **Research mode · Analysis only · no execution** is unchanged in the sidebar.

```bash
pnpm --filter @pmh/studio test
```

Existing Studio tests do not assert the old strings. This PR does not add product behavior, so no new test file was required.