### PR TITLE
Demote radar pair spend CTAs so they do not look free

### DIFF
--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -11021,10 +11021,13 @@ function OpportunityRadarView() {
                     <ShieldCheck size={14} />
                     <span>
                       Exact two-listing context · proposal only · no auto spend
+                      · a click spends scout or pi budget
                     </span>
                   </div>
                   <div className="radar-action-buttons">
                     <Button
+                      variant="outline"
+                      title="Starts a bounded cheap-scout model run. Not free. Does not place orders."
                       disabled={running || studioProjection.ai.activeRuns > 0}
                       onClick={() => void triage(candidate)}
                     >
@@ -11034,17 +11037,18 @@ function OpportunityRadarView() {
                         <Sparkles size={14} />
                       )}
                       {running
-                        ? "Scouts triaging…"
+                        ? "Spending scout budget…"
                         : localState === "DONE"
                           ? "Triage complete"
                           : localState === "RESTORED" || retained
                             ? "Restore scout result"
                             : localState === "FAILED"
-                              ? "Retry scout triage"
-                              : "Triage with fast scouts"}
+                              ? "Retry scout spend"
+                              : "Spend scout budget to triage"}
                     </Button>
                     <Button
                       variant="outline"
+                      title="Starts a bounded deep-pi model run. Not free. Does not place orders."
                       disabled={
                         !retained ||
                         !studioProjection.ai.investigator.configured ||
@@ -11059,7 +11063,7 @@ function OpportunityRadarView() {
                         <SquareTerminal size={14} />
                       )}
                       {investigating
-                        ? "pi investigating…"
+                        ? "Spending deep-pi budget…"
                         : investigationState === "DONE"
                           ? "pi complete"
                           : investigationState === "RESTORED" ||
@@ -11067,8 +11071,8 @@ function OpportunityRadarView() {
                             ? "Restore pi report"
                             : investigationState === "FAILED" ||
                                 investigationRecord?.status === "FAILED"
-                              ? "Retry deep pi"
-                              : "Run deep pi"}
+                              ? "Retry deep-pi spend"
+                              : "Spend deep-pi model budget"}
                     </Button>
                   </div>
                 </div>


### PR DESCRIPTION
Fixes #11.

## Problem

On `?view=radar`, pair rows showed a filled primary **Triage with fast scouts** next to **Run deep pi**, beside the green POSITIVE GROSS HINT / bps figure. Nearby copy said **proposal only · no auto spend**.

Triage starts a bounded model/heuristic run. “No auto spend” could be read as “clicking is free.”

## Change

Independent of #8/#9 header/summary copy. Only the per-pair action row in `OpportunityRadarView`:

- Both spend buttons are outline, not a filled primary CTA.
- Idle/retry labels name the action as scout or deep-pi budget spend.
- Helper copy keeps **no auto spend** and adds that a click spends scout or pi budget: the page will not fire without a click, and the click is not free.
- Tooltips repeat that these are bounded model runs and do not place orders.

Restore labels stay restore-only. Click handlers, radar math, refresh, credentials, orders, and execution authority are unchanged. Triage/pi are not auto-started and were not invoked in this change.

## Out of scope

- #8 / #9 header and summary copy
- #10, #12, #13, #14
- Findings Explore-next styling
- Live triage or any value-moving path
