### PR TITLE
Mark Markets ORDER_GATEWAY chips as inert coverage

### DIFF
--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -71,6 +71,7 @@ import {
   type StandingRouteUsage,
 } from "@/data/standing-routes";
 import { cn } from "@/lib/utils";
+import { presentVenueCapabilityChips } from "@/lib/venue-capability-chip";
 import {
   parseWorkspaceRoute,
   serializeWorkspaceRoute,
@@ -12800,8 +12801,16 @@ function VenueMatrix() {
                 </div>
               </div>
               <div className="capability-chips">
-                {venue.capabilities.map((capability) => (
-                  <span key={capability}>{capability}</span>
+                {presentVenueCapabilityChips(
+                  venue.capabilities,
+                  venue.liveExecutionEnabled,
+                ).map((chip) => (
+                  <span
+                    key={chip.key}
+                    className={chip.inert ? "is-inert" : undefined}
+                  >
+                    {chip.label}
+                  </span>
                 ))}
               </div>
             </CardContent>

--- a/apps/studio/src/data/studio-projection.test.ts
+++ b/apps/studio/src/data/studio-projection.test.ts
@@ -5,6 +5,7 @@ import {
   RealCandidatePreflightDesk,
   ReplayBookDesk,
 } from "@pmh/control-plane";
+import { presentVenueCapabilityChips } from "../lib/venue-capability-chip.js";
 import {
   parseStartupReadiness,
   parseProjectionInvalidation,
@@ -384,6 +385,35 @@ describe("Studio projection safety", () => {
     expect(inertVenues.every((venue) => !venue.liveExecutionEnabled)).toBe(
       true,
     );
+    expect(
+      inertVenues.flatMap((venue) =>
+        presentVenueCapabilityChips(
+          venue.capabilities,
+          venue.liveExecutionEnabled,
+        ),
+      ).filter((chip) => chip.key === "ORDER_GATEWAY"),
+    ).toEqual([
+      {
+        key: "ORDER_GATEWAY",
+        label: "ORDER_GATEWAY · INERT",
+        inert: true,
+      },
+      {
+        key: "ORDER_GATEWAY",
+        label: "ORDER_GATEWAY · INERT",
+        inert: true,
+      },
+    ]);
+    expect(
+      studioProjection.venues
+        .flatMap((venue) =>
+          presentVenueCapabilityChips(
+            venue.capabilities,
+            venue.liveExecutionEnabled,
+          ),
+        )
+        .some((chip) => chip.key === "ORDER_GATEWAY" && !chip.inert),
+    ).toBe(false);
   });
 
   it("labels every displayed opportunity as exact fixture evidence", () => {

--- a/apps/studio/src/index.css
+++ b/apps/studio/src/index.css
@@ -1311,6 +1311,12 @@ main {
   padding: 4px 6px;
 }
 
+.capability-chips span.is-inert {
+  border-color: rgba(255, 199, 142, 0.22);
+  background: rgba(255, 199, 142, 0.04);
+  color: #c99e75;
+}
+
 .scout-heading {
   padding-bottom: 32px;
 }

--- a/apps/studio/src/lib/venue-capability-chip.test.ts
+++ b/apps/studio/src/lib/venue-capability-chip.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { presentVenueCapabilityChip } from "./venue-capability-chip.js";
+
+describe("Markets venue capability chips", () => {
+  it("marks ORDER_GATEWAY as inert coverage when live execution is disabled", () => {
+    expect(presentVenueCapabilityChip("ORDER_GATEWAY", false)).toEqual({
+      key: "ORDER_GATEWAY",
+      label: "ORDER_GATEWAY · INERT",
+      inert: true,
+    });
+  });
+
+  it("does not restyle catalog coverage as an order surface", () => {
+    expect(presentVenueCapabilityChip("MARKET_CATALOG", false)).toEqual({
+      key: "MARKET_CATALOG",
+      label: "MARKET_CATALOG",
+      inert: false,
+    });
+  });
+});

--- a/apps/studio/src/lib/venue-capability-chip.ts
+++ b/apps/studio/src/lib/venue-capability-chip.ts
@@ -1,0 +1,32 @@
+export type VenueCapabilityChip = Readonly<{
+  key: string;
+  label: string;
+  inert: boolean;
+}>;
+
+export function presentVenueCapabilityChip(
+  capability: string,
+  liveExecutionEnabled: boolean,
+): VenueCapabilityChip {
+  if (capability === "ORDER_GATEWAY" && liveExecutionEnabled !== true) {
+    return {
+      key: capability,
+      label: "ORDER_GATEWAY · INERT",
+      inert: true,
+    };
+  }
+  return {
+    key: capability,
+    label: capability,
+    inert: false,
+  };
+}
+
+export function presentVenueCapabilityChips(
+  capabilities: readonly string[],
+  liveExecutionEnabled: boolean,
+): readonly VenueCapabilityChip[] {
+  return capabilities.map((capability) =>
+    presentVenueCapabilityChip(capability, liveExecutionEnabled),
+  );
+}


### PR DESCRIPTION
Fixes #12

Independent of #5 / #6 / #7 / #15 / #16. This PR is a new branch from `origin/main` only; it does not stack on those radar/sidebar/copy branches.

## What changed

On `?view=markets`, Gemini and Kalshi already showed **INERT SANDBOX GATEWAY** / **INERT DEMO GATEWAY**, but the **ORDER_GATEWAY** capability chip used the same neutral styling as catalog/book chips. Next to the green Fixture health bar that read as armed trading, even though `liveExecutionEnabled` is false.

When live execution is disabled, the chip is now **ORDER_GATEWAY · INERT** and uses the same amber inert treatment as the gateway pills. Other chips (`MARKET_CATALOG`, `REALTIME_BOOK`, …) are unchanged. Venues without an order gateway still show **ORDER GATEWAY ABSENT**. No execution, signing, funds, or OAuth path was added.

## How to check

1. Open Studio at `/?view=markets` (do not enable trading).
2. On Gemini: capability row should show **ORDER_GATEWAY · INERT** next to **INERT SANDBOX GATEWAY**, same muted amber/brown outline — not an armed-trading look.
3. On Kalshi: **ORDER_GATEWAY · INERT** next to **INERT DEMO GATEWAY**.
4. Other venues still show **ORDER GATEWAY ABSENT** and no order chip.
5. Sidebar remains **Analysis only · no execution**.

## Tests

- `apps/studio/src/lib/venue-capability-chip.test.ts` — focused chip-label test
- `apps/studio/src/data/studio-projection.test.ts` — existing Gemini/Kalshi inert-posture test now asserts both `ORDER_GATEWAY` chips are inert