### PR TITLE
Point review-queue NEEDS KEY badges at Agent operations

### DIFF
--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -71,6 +71,7 @@ import {
   type StandingRouteUsage,
 } from "@/data/standing-routes";
 import { cn } from "@/lib/utils";
+import { reviewQueueNeedsKeyPath } from "@/lib/review-queue-needs-key";
 import {
   parseWorkspaceRoute,
   serializeWorkspaceRoute,
@@ -8789,6 +8790,10 @@ function OpportunityLifecycleView({
     1,
     ...recentUsageHours.map((bucket) => Number(bucket.invocationCount)),
   );
+  const needsKeyPath = reviewQueueNeedsKeyPath({
+    reviewerConfigured: semanticReview.configured,
+    estimatorsConfigured: probabilityEstimation.configured,
+  });
 
   return (
     <section className="page-section lifecycle-page">
@@ -8816,6 +8821,17 @@ function OpportunityLifecycleView({
           <Badge variant="warning">LIVE ROUTE ABSENT</Badge>
         </div>
       </div>
+
+      {needsKeyPath !== null && (
+        <div className="inline-alert" role="status">
+          <CircleOff size={14} />
+          <span>
+            The review lane is idle until the existing{" "}
+            <a href={needsKeyPath}>Agent operations</a>
+            {" "}session exists.
+          </span>
+        </div>
+      )}
 
       {focusedProposalIds.length > 0 && (
         <section className="focused-review-handoff" aria-label="Focused finding review handoff">

--- a/apps/studio/src/lib/review-queue-needs-key.test.ts
+++ b/apps/studio/src/lib/review-queue-needs-key.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { reviewQueueNeedsKeyPath } from "./review-queue-needs-key.js";
+import { serializeWorkspaceRoute } from "./workspace-route.js";
+
+describe("review queue NEEDS KEY path", () => {
+  it("returns null when reviewer and estimators are configured", () => {
+    expect(reviewQueueNeedsKeyPath({
+      reviewerConfigured: true,
+      estimatorsConfigured: true,
+    })).toBeNull();
+  });
+
+  it("points at Agent operations when the reviewer is not configured", () => {
+    expect(reviewQueueNeedsKeyPath({
+      reviewerConfigured: false,
+      estimatorsConfigured: true,
+    })).toBe(serializeWorkspaceRoute("agents"));
+    expect(reviewQueueNeedsKeyPath({
+      reviewerConfigured: false,
+      estimatorsConfigured: true,
+    })).toBe("?view=agents");
+  });
+
+  it("points at Agent operations when estimators are not configured", () => {
+    expect(reviewQueueNeedsKeyPath({
+      reviewerConfigured: true,
+      estimatorsConfigured: false,
+    })).toBe("?view=agents");
+  });
+
+  it("points at Agent operations when neither lane is configured", () => {
+    expect(reviewQueueNeedsKeyPath({
+      reviewerConfigured: false,
+      estimatorsConfigured: false,
+    })).toBe("?view=agents");
+  });
+});

--- a/apps/studio/src/lib/review-queue-needs-key.ts
+++ b/apps/studio/src/lib/review-queue-needs-key.ts
@@ -1,0 +1,11 @@
+import { serializeWorkspaceRoute } from "./workspace-route.js";
+
+export function reviewQueueNeedsKeyPath(input: {
+  readonly reviewerConfigured: boolean;
+  readonly estimatorsConfigured: boolean;
+}): string | null {
+  if (input.reviewerConfigured && input.estimatorsConfigured) {
+    return null;
+  }
+  return serializeWorkspaceRoute("agents");
+}

--- a/apps/studio/src/product-shell.css
+++ b/apps/studio/src/product-shell.css
@@ -3604,6 +3604,12 @@ footer {
   font-size: 13px;
 }
 
+.inline-alert a {
+  color: inherit;
+  font-weight: 650;
+  text-decoration: underline;
+}
+
 @media (max-width: 900px) {
   .agent-console-grid,
   .agent-control-form,


### PR DESCRIPTION
## Summary
- `?view=review` still fail-closes with REVIEWER NEEDS KEY / ESTIMATORS NEED KEY; it now says the review lane is idle until the existing Agent operations session exists and links to `?view=agents`.
- No key-entry form, OAuth wizard, or live execution. Analysis only / no execution is unchanged.

Fixes #10

## Test plan
- [x] Studio package tests: 34 passed, including review-queue-needs-key.test.ts
- [x] Playwright on existing http://127.0.0.1:5173/?view=review: next path visible, no key form, Analysis only / no execution unchanged; did not click trade/triage
