### PR TITLE
Stop labeling idle Evidence claims as RUNNING

### DIFF
--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -77,6 +77,7 @@ import {
   workspaceReadModel,
   type WorkspaceView,
 } from "@/lib/workspace-route";
+import { verifiedClaimsPipelineState } from "@/lib/evidence-pipeline-stage";
 
 type View = WorkspaceView;
 type Opportunity = StudioProjection["opportunities"][number];
@@ -13502,7 +13503,7 @@ function EvidenceView({
       label: "Verified claims",
       value: ruleEvidenceClaims.passedCount,
       detail: `${ruleEvidenceClaims.pendingCount + ruleEvidenceClaims.activeCount} in Agent loop · ${ruleEvidenceClaims.interruptedLeaseCount} interrupted`,
-      state: ruleEvidenceClaims.passedCount > 0 ? "INTERPRETED" : "RUNNING",
+      state: verifiedClaimsPipelineState(ruleEvidenceClaims),
     },
     {
       step: "05",

--- a/apps/studio/src/lib/evidence-pipeline-stage.test.ts
+++ b/apps/studio/src/lib/evidence-pipeline-stage.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { verifiedClaimsPipelineState } from "./evidence-pipeline-stage.js";
+
+describe("verifiedClaimsPipelineState", () => {
+  it("is interpreted after a passed claim", () => {
+    expect(verifiedClaimsPipelineState({
+      passedCount: 1,
+      pendingCount: 0,
+      activeCount: 0,
+    })).toBe("INTERPRETED");
+  });
+
+  it("is running only while claims are in the Agent loop", () => {
+    expect(verifiedClaimsPipelineState({
+      passedCount: 0,
+      pendingCount: 1,
+      activeCount: 0,
+    })).toBe("RUNNING");
+    expect(verifiedClaimsPipelineState({
+      passedCount: 0,
+      pendingCount: 0,
+      activeCount: 2,
+    })).toBe("RUNNING");
+  });
+
+  it("is waiting when the lane is idle so PAUSED desks do not show RUNNING", () => {
+    expect(verifiedClaimsPipelineState({
+      passedCount: 0,
+      pendingCount: 0,
+      activeCount: 0,
+    })).toBe("WAITING");
+  });
+});

--- a/apps/studio/src/lib/evidence-pipeline-stage.ts
+++ b/apps/studio/src/lib/evidence-pipeline-stage.ts
@@ -1,0 +1,13 @@
+export type VerifiedClaimsCounts = Readonly<{
+  passedCount: number;
+  pendingCount: number;
+  activeCount: number;
+}>;
+
+export function verifiedClaimsPipelineState(
+  claims: VerifiedClaimsCounts,
+): "INTERPRETED" | "RUNNING" | "WAITING" {
+  if (claims.passedCount > 0) return "INTERPRETED";
+  if (claims.pendingCount + claims.activeCount > 0) return "RUNNING";
+  return "WAITING";
+}


### PR DESCRIPTION
Fixes #13

Independent of #5 / #6 / #7 / #15 / #16 / #17 / #18. This PR is a new branch from `origin/main` only; it does not stack on those branches.

## What changed

On `?view=evidence`, the header can read **PAUSED** while stage 04 **Verified claims** always said **RUNNING** whenever `passedCount` was 0. An idle desk (0 in-loop, 0 interrupted) looked like it was consuming the Agent loop.

Stage 04 is now:

- **INTERPRETED** after a passed claim
- **RUNNING** only while `pendingCount + activeCount > 0`
- **WAITING** when the lane is idle

No evidence-claim jobs are started. No spend, signing, funds, or OAuth path was added.

## How to check

1. Open Studio at `/?view=evidence` (do not enable trading or start claim jobs).
2. With a PAUSED / idle desk and 0 passed claims, stage 04 should read **WAITING**, not **RUNNING**.
3. Other zero-state stages stay as they are.
4. Sidebar remains **Analysis only · no execution**.

## Tests

- `apps/studio/src/lib/evidence-pipeline-stage.test.ts` — idle is WAITING, in-loop is RUNNING, passed is INTERPRETED