### PR TITLE
Name the Agents task counts so 150 / 0 / 128 are not one tile

### DIFF
--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -77,6 +77,7 @@ import {
   workspaceReadModel,
   type WorkspaceView,
 } from "@/lib/workspace-route";
+import { agentTaskRunTile } from "@/lib/agent-task-run-tile";
 
 type View = WorkspaceView;
 type Opportunity = StudioProjection["opportunities"][number];
@@ -4619,7 +4620,7 @@ function AgentOperationsView() {
       <div className="metric-grid agent-metrics">
         <Metric label="Runtimes" value={`${consoleData.summary.runtimeDefinitionCount}`} detail="Pi · Codex · in-process" />
         <Metric label="Execution profiles" value={`${consoleData.summary.executionProfileCount}`} detail="immutable runtime/model compositions" />
-        <Metric label="Tasks / runs" value={`${consoleData.summary.taskCount} / ${consoleData.summary.runCount}`} detail={`${runnableTaskCount} current · ${supersededTaskCount} superseded in view`} />
+        <Metric {...agentTaskRunTile({ taskCount: consoleData.summary.taskCount, runCount: consoleData.summary.runCount, runnableCount: runnableTaskCount })} />
         <Metric label="Known tokens" value={formatTokenCount((BigInt(consoleData.usage.inputTokens) + BigInt(consoleData.usage.outputTokens)).toString())} detail={`${consoleData.usage.incompleteTokenInvocationCount} invocations incomplete`} />
       </div>
 

--- a/apps/studio/src/lib/agent-task-run-tile.test.ts
+++ b/apps/studio/src/lib/agent-task-run-tile.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { agentTaskRunTile } from "./agent-task-run-tile.js";
+
+describe("agentTaskRunTile", () => {
+  it("puts retained tasks in the headline and names the other two counts", () => {
+    expect(agentTaskRunTile({
+      taskCount: 150,
+      runCount: 0,
+      runnableCount: 128,
+    })).toEqual({
+      label: "Tasks",
+      value: "150",
+      detail: "128 runnable · 0 runs",
+    });
+  });
+
+  it("does not put a slash pair in the value so idle desks do not look stalled", () => {
+    const tile = agentTaskRunTile({
+      taskCount: 150,
+      runCount: 0,
+      runnableCount: 128,
+    });
+    expect(tile.value.includes("/")).toBe(false);
+  });
+});

--- a/apps/studio/src/lib/agent-task-run-tile.ts
+++ b/apps/studio/src/lib/agent-task-run-tile.ts
@@ -1,0 +1,19 @@
+export type AgentTaskRunCounts = Readonly<{
+  taskCount: number;
+  runCount: number;
+  runnableCount: number;
+}>;
+
+export type AgentTaskRunTile = Readonly<{
+  label: string;
+  value: string;
+  detail: string;
+}>;
+
+export function agentTaskRunTile(counts: AgentTaskRunCounts): AgentTaskRunTile {
+  return {
+    label: "Tasks",
+    value: String(counts.taskCount),
+    detail: `${counts.runnableCount} runnable · ${counts.runCount} runs`,
+  };
+}


### PR DESCRIPTION
Fixes #20

Independent of #5 / #6 / #7 / #15 / #16 / #17 / #18 / #19. This PR is a new branch from `origin/main` only; it does not stack on those branches. #14 stays pressed.

## What changed

On `?view=agents`, **Tasks / runs** showed **150 / 0** with **128 current** underneath. An idle desk (0 runs, 0 tokens) looked like a stalled queue.

The tile now has one headline number:

- **Tasks 150**
- detail **128 runnable · 0 runs**

No run, campaign, dispatch, or claim CTA was added on this tile. No spend, signing, or funds path was added.

## How to check

1. Open Studio at `/?view=agents` (do not start a run or campaign).
2. The third metric should read **Tasks** with a single headline count, not **150 / 0**.
3. The detail should name **runnable** and **runs** separately.
4. Sidebar remains **Analysis only · no execution**.

## Tests

- `apps/studio/src/lib/agent-task-run-tile.test.ts` — observed 150 / 0 / 128 becomes a single headline plus named detail