### PR TITLE
Name the books tile from the venue sessions on screen

### DIFF
--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -72,6 +72,11 @@ import {
 } from "@/data/standing-routes";
 import { cn } from "@/lib/utils";
 import {
+  qualifiedBooksTile,
+  selectedVenueSessionLabel,
+  VENUE_SESSION_PICKER_HEADING,
+} from "@/lib/book-desk-copy";
+import {
   parseWorkspaceRoute,
   serializeWorkspaceRoute,
   workspaceReadModel,
@@ -12884,11 +12889,7 @@ function BookDeskView() {
       </div>
 
       <div className="book-summary-grid">
-        <Metric
-          label="Qualified books"
-          value={`${studioProjection.bookDesk.books.length}`}
-          detail="three public transports"
-        />
+        <Metric {...qualifiedBooksTile(studioProjection.bookDesk.books)} />
         <Metric
           label="Replay generation"
           value={`${studioProjection.bookDesk.replayCount}`}
@@ -12904,31 +12905,35 @@ function BookDeskView() {
       <div className="book-desk-layout">
         <div className="book-session-list">
           <div className="book-list-heading">
-            <span>Venue sessions</span>
+            <span>{VENUE_SESSION_PICKER_HEADING}</span>
             <Badge variant="verified">
               <Radio size={10} /> SSE linked
             </Badge>
           </div>
-          {studioProjection.bookDesk.books.map((book) => (
-            <button
-              className={cn(
-                "book-session",
-                selectedBook?.bookId === book.bookId && "is-selected",
-              )}
-              key={book.bookId}
-              onClick={() => setSelectedBookId(book.bookId)}
-            >
-              <span className="book-session-status" />
-              <div>
-                <strong>{book.venueName}</strong>
-                <span>{book.instrumentId}</span>
-              </div>
-              <Badge variant="muted">{book.lifecycle}</Badge>
-              <small>
-                {book.bidLevelCount} × {book.askLevelCount} levels
-              </small>
-            </button>
-          ))}
+          {studioProjection.bookDesk.books.map((book) => {
+            const selected = selectedBook?.bookId === book.bookId;
+            const showingLabel = selectedVenueSessionLabel(selected);
+            return (
+              <button
+                className={cn("book-session", selected && "is-selected")}
+                key={book.bookId}
+                onClick={() => setSelectedBookId(book.bookId)}
+              >
+                <span className="book-session-status" />
+                <div>
+                  <strong>{book.venueName}</strong>
+                  <span>{book.instrumentId}</span>
+                  {showingLabel !== undefined && (
+                    <b className="book-session-showing">{showingLabel}</b>
+                  )}
+                </div>
+                <Badge variant="muted">{book.lifecycle}</Badge>
+                <small>
+                  {book.bidLevelCount} × {book.askLevelCount} levels
+                </small>
+              </button>
+            );
+          })}
         </div>
 
         {selectedBook && (

--- a/apps/studio/src/index.css
+++ b/apps/studio/src/index.css
@@ -4162,6 +4162,13 @@ main {
   font-size: 13px;
 }
 
+.book-session-showing {
+  color: var(--primary);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
 .book-session > div span,
 .book-session small {
   overflow: hidden;

--- a/apps/studio/src/lib/book-desk-copy.test.ts
+++ b/apps/studio/src/lib/book-desk-copy.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  qualifiedBooksTile,
+  selectedVenueSessionLabel,
+  VENUE_SESSION_PICKER_HEADING,
+} from "./book-desk-copy.js";
+
+const fourVenueSessions = [
+  { bookId: "gemini-predictions:yes" },
+  { bookId: "limitless:yes" },
+  { bookId: "polymarket-global:yes" },
+  { bookId: "polymarket-us:yes" },
+] as const;
+
+describe("qualifiedBooksTile", () => {
+  it("names the qualified-books tile from the sessions on screen", () => {
+    expect(qualifiedBooksTile(fourVenueSessions)).toEqual({
+      label: "Qualified books",
+      value: "4",
+      detail: "4 venue sessions",
+    });
+  });
+
+  it("does not hardcode a three-transport count", () => {
+    expect(qualifiedBooksTile([{ bookId: "gemini-predictions:yes" }])).toEqual({
+      label: "Qualified books",
+      value: "1",
+      detail: "1 venue session",
+    });
+    expect(qualifiedBooksTile([])).toEqual({
+      label: "Qualified books",
+      value: "0",
+      detail: "0 venue sessions",
+    });
+  });
+});
+
+describe("venue session picker copy", () => {
+  it("labels the list as a selector and the selected row as Showing", () => {
+    expect(VENUE_SESSION_PICKER_HEADING).toBe("Select a venue session");
+    expect(selectedVenueSessionLabel(true)).toBe("Showing");
+    expect(selectedVenueSessionLabel(false)).toBeUndefined();
+  });
+});

--- a/apps/studio/src/lib/book-desk-copy.ts
+++ b/apps/studio/src/lib/book-desk-copy.ts
@@ -1,0 +1,23 @@
+export type QualifiedBooksTile = Readonly<{
+  label: string;
+  value: string;
+  detail: string;
+}>;
+
+export const VENUE_SESSION_PICKER_HEADING = "Select a venue session";
+export const SELECTED_VENUE_SESSION_LABEL = "Showing";
+
+export function qualifiedBooksTile(
+  books: readonly Readonly<{ bookId: string }>[],
+): QualifiedBooksTile {
+  const count = books.length;
+  return {
+    label: "Qualified books",
+    value: String(count),
+    detail: count === 1 ? "1 venue session" : `${count} venue sessions`,
+  };
+}
+
+export function selectedVenueSessionLabel(selected: boolean): string | undefined {
+  return selected ? SELECTED_VENUE_SESSION_LABEL : undefined;
+}


### PR DESCRIPTION
Fixes #22

Independent of #14 / #19 / #21. This PR is a new branch from `origin/main` only; it does not stack on those branches. #14 stays pressed.

## What changed

On `?view=books`, **Qualified books 4** still said **three public transports**, and the four **SNAPSHOT_VALID** rows read as a status list. Only the Gemini ladder was obviously open.

The tile detail is now **N venue sessions**. The list heading is **Select a venue session**, and the selected row is labeled **Showing**. No replay, trade, or spend CTA was added.

## How to check

1. Open Studio at `/?view=books` (do not click Replay evidence).
2. The first tile should say **4 venue sessions**, not **three public transports**.
3. The left list heading should say **Select a venue session**; Gemini (or the selected row) should read **Showing**.
4. Clicking another session should switch the ladder. Sidebar remains **Analysis only · no execution**.

## Tests

- `apps/studio/src/lib/book-desk-copy.test.ts` — 4 books → "4 venue sessions"; 1 book singular; selected row is Showing