### PR TITLE
Filter the command palette to existing projections

### DIFF
--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Activity,
   BadgeCheck,
@@ -70,6 +70,10 @@ import {
   type StandingRouteState,
   type StandingRouteUsage,
 } from "@/data/standing-routes";
+import {
+  filterProjectionCommands,
+  stepCommandIndex,
+} from "@/lib/command-palette";
 import { cn } from "@/lib/utils";
 import {
   parseWorkspaceRoute,
@@ -13968,7 +13972,33 @@ function CommandPalette({
   onClose: () => void;
   onNavigate: (view: View) => void;
 }) {
+  const [query, setQuery] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const resultsRef = useRef<HTMLDivElement>(null);
+  const matches = filterProjectionCommands(navigation, query);
+
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setSelectedIndex(0);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    resultsRef.current
+      ?.querySelector<HTMLElement>("[aria-selected='true']")
+      ?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex, query]);
+
   if (!open) return null;
+
+  function activate(index: number): void {
+    const item = matches[index];
+    if (item === undefined) return;
+    onNavigate(item.id);
+    onClose();
+  }
+
   return (
     <div className="command-layer" role="dialog" aria-modal="true">
       <button
@@ -13982,27 +14012,66 @@ function CommandPalette({
           <Input
             autoFocus
             aria-label="Search commands"
+            aria-controls="command-palette-results"
+            aria-activedescendant={
+              matches[selectedIndex] === undefined
+                ? undefined
+                : `command-${matches[selectedIndex].id}`
+            }
             placeholder="Jump to a projection…"
+            value={query}
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setSelectedIndex(0);
+            }}
+            onKeyDown={(event) => {
+              if (event.key === "ArrowDown") {
+                event.preventDefault();
+                setSelectedIndex((index) => stepCommandIndex(matches.length, index, 1));
+              } else if (event.key === "ArrowUp") {
+                event.preventDefault();
+                setSelectedIndex((index) => stepCommandIndex(matches.length, index, -1));
+              } else if (event.key === "Enter") {
+                event.preventDefault();
+                activate(selectedIndex);
+              }
+            }}
           />
           <kbd>ESC</kbd>
         </div>
         <span className="command-group-label">Available projections</span>
-        {navigation.map((item) => {
-          const Icon = item.icon;
-          return (
-            <button
-              key={item.id}
-              onClick={() => {
-                onNavigate(item.id);
-                onClose();
-              }}
-            >
-              <Icon size={16} />
-              <span>{item.label}</span>
-              <small>Open</small>
-            </button>
-          );
-        })}
+        <div
+          ref={resultsRef}
+          id="command-palette-results"
+          className="command-results"
+          role="listbox"
+          aria-label="Available projections"
+        >
+          {matches.length === 0 ? (
+            <p className="command-empty" role="status">
+              No projections match that query.
+            </p>
+          ) : (
+            matches.map((item, index) => {
+              const Icon = item.icon;
+              return (
+                <button
+                  key={item.id}
+                  id={`command-${item.id}`}
+                  role="option"
+                  aria-selected={index === selectedIndex}
+                  className={index === selectedIndex ? "is-active" : undefined}
+                  onMouseEnter={() => setSelectedIndex(index)}
+                  onClick={() => activate(index)}
+                >
+                  <Icon size={16} />
+                  <span>{item.label}</span>
+                  <small>Open</small>
+                </button>
+              );
+            })
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/studio/src/index.css
+++ b/apps/studio/src/index.css
@@ -4870,7 +4870,11 @@ footer span:first-child {
 
 .command-palette {
   position: relative;
+  display: flex;
+  flex-direction: column;
   width: min(540px, calc(100vw - 28px));
+  /* Leave the last projection rows reachable instead of clipping them. */
+  max-height: calc(100vh - min(18vh, 150px) - 24px);
   overflow: hidden;
   border: 1px solid #2b3437;
   border-radius: 13px;
@@ -4920,7 +4924,20 @@ footer span:first-child {
   text-transform: uppercase;
 }
 
-.command-palette > button:not(.command-scrim) {
+.command-results {
+  min-height: 0;
+  overflow-y: auto;
+  padding-bottom: 6px;
+}
+
+.command-empty {
+  color: #7b8580;
+  font-size: 13px;
+  margin: 0;
+  padding: 18px 15px 22px;
+}
+
+.command-results > button {
   display: grid;
   width: calc(100% - 12px);
   height: 43px;
@@ -4937,12 +4954,13 @@ footer span:first-child {
   text-align: left;
 }
 
-.command-palette > button:not(.command-scrim):hover {
+.command-results > button.is-active,
+.command-results > button:hover {
   background: rgba(126, 240, 193, 0.07);
   color: var(--primary);
 }
 
-.command-palette button small {
+.command-results button small {
   color: #56605b;
   font-family: inherit;
   font-size: 12px;

--- a/apps/studio/src/lib/command-palette.test.ts
+++ b/apps/studio/src/lib/command-palette.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterProjectionCommands,
+  stepCommandIndex,
+} from "./command-palette.js";
+
+const projections = [
+  { id: "archaeologist", label: "Discover" },
+  { id: "scouts", label: "Findings" },
+  { id: "budgets", label: "Failure budgets" },
+  { id: "lifecycle", label: "Review queue" },
+  { id: "preflight", label: "Preflight" },
+  { id: "venues", label: "Markets" },
+  { id: "evidence", label: "Evidence" },
+  { id: "overview", label: "System overview" },
+  { id: "agents", label: "Agent operations" },
+  { id: "radar", label: "Similarity radar" },
+  { id: "cases", label: "Research cases" },
+  { id: "books", label: "Order books" },
+] as const;
+
+describe("command palette projection filter", () => {
+  it("keeps every existing projection when the query is empty", () => {
+    expect(filterProjectionCommands(projections, "")).toEqual(projections);
+    expect(filterProjectionCommands(projections, "   ")).toEqual(projections);
+  });
+
+  it("filters visible projection labels as the operator types", () => {
+    expect(filterProjectionCommands(projections, "book").map((item) => item.id))
+      .toEqual(["books"]);
+    expect(filterProjectionCommands(projections, "REVIEW").map((item) => item.label))
+      .toEqual(["Review queue"]);
+    expect(filterProjectionCommands(projections, "radar")).toEqual([
+      projections.find((item) => item.id === "radar"),
+    ]);
+  });
+
+  it("returns no destinations when nothing matches", () => {
+    expect(filterProjectionCommands(projections, "dispatch spend")).toEqual([]);
+    expect(filterProjectionCommands(projections, "zzz")).toEqual([]);
+  });
+
+  it("does not invent commands from internal view ids", () => {
+    expect(filterProjectionCommands(projections, "scouts")).toEqual([]);
+    expect(filterProjectionCommands(projections, "lifecycle")).toEqual([]);
+  });
+
+  it("wraps keyboard highlight across the filtered rows", () => {
+    expect(stepCommandIndex(12, 11, 1)).toBe(0);
+    expect(stepCommandIndex(12, 0, -1)).toBe(11);
+    expect(stepCommandIndex(1, 0, 1)).toBe(0);
+    expect(stepCommandIndex(0, 3, 1)).toBe(0);
+  });
+});

--- a/apps/studio/src/lib/command-palette.ts
+++ b/apps/studio/src/lib/command-palette.ts
@@ -1,0 +1,22 @@
+export type ProjectionCommand = Readonly<{
+  id: string;
+  label: string;
+}>;
+
+export function filterProjectionCommands<T extends ProjectionCommand>(
+  items: readonly T[],
+  query: string,
+): readonly T[] {
+  const needle = query.trim().toLowerCase();
+  if (needle.length === 0) return items;
+  return items.filter((item) => item.label.toLowerCase().includes(needle));
+}
+
+export function stepCommandIndex(
+  count: number,
+  current: number,
+  delta: 1 | -1,
+): number {
+  if (count <= 0) return 0;
+  return (current + delta + count) % count;
+}


### PR DESCRIPTION
Fixes #23

Independent of #14 / #19 / #21 / #24. This PR is a new branch from `origin/main` only. #14 stays pressed.

## What changed

Top bar **Find anything ⌘K** opened a dialog whose field did not filter. Typing left all 12 rows; the list clipped at **Order books**.

The query now filters the existing projection labels. No match shows **No projections match that query.** The list scrolls, and arrow keys + Enter move a highlight. No spend, triage, claim, or dispatch commands were added.

## How to check

1. Open Studio and press Cmd-K or click Find anything (do not start spend).
2. Type zzz — the list should empty with the no-match line, not stay at 12 rows.
3. Type book — only Order books.
4. Clear the query, arrow to the last row, confirm it is reachable. Sidebar remains Analysis only · no execution.

## Tests

- apps/studio/src/lib/command-palette.test.ts — empty query keeps 12; zzz matches none; arrows wrap