### PR TITLE
Stop offering a green Explore next when the System scout cannot run

### DIFF
--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -71,6 +71,7 @@ import {
   type StandingRouteUsage,
 } from "@/data/standing-routes";
 import { cn } from "@/lib/utils";
+import { systemExploreNextAction } from "@/lib/system-explore-next";
 import {
   parseWorkspaceRoute,
   serializeWorkspaceRoute,
@@ -5950,6 +5951,12 @@ function Overview({
 }) {
   const studioProjection = useStudioProjection();
   const catalogObservation = studioProjection.ai.catalogObservation;
+  const discoveryExecution = useDiscoveryExecutionCapability();
+  const exploreNext = systemExploreNextAction({
+    workers: studioProjection.ai.workers,
+    dispatchEligibility:
+      discoveryExecution.data?.capability.dispatchEligibility ?? null,
+  });
   const [scoutStatus, setScoutStatus] = useState<
     "IDLE" | "RUNNING" | "DONE" | "RESTORED" | "FAILED"
   >("IDLE");
@@ -6067,22 +6074,43 @@ function Overview({
               <p>The scheduler chooses a fresh trailhead; the Agent forms claims after inspection.</p>
             </div>
           </div>
-          <Button
-            disabled={scoutStatus === "RUNNING"}
-            onClick={() => void runScout()}
-          >
-            <Sparkles size={11} />
-            {scoutStatus === "RUNNING"
-              ? "Scouting…"
-              : scoutStatus === "DONE"
-                ? "Scan complete"
-                : scoutStatus === "RESTORED"
-                  ? "Already scanned"
-                : scoutStatus === "FAILED"
-                  ? "Retry scout"
-                  : "Explore next"}
-          </Button>
+          {exploreNext.kind === "SCOUT" ? (
+            <Button
+              disabled={scoutStatus === "RUNNING"}
+              onClick={() => void runScout()}
+            >
+              <Sparkles size={11} />
+              {scoutStatus === "RUNNING"
+                ? "Scouting…"
+                : scoutStatus === "DONE"
+                  ? "Scan complete"
+                  : scoutStatus === "RESTORED"
+                    ? "Already scanned"
+                    : scoutStatus === "FAILED"
+                      ? "Retry scout"
+                      : exploreNext.label}
+            </Button>
+          ) : (
+            <Button
+              variant="outline"
+              onClick={() => {
+                window.location.assign(exploreNext.href);
+              }}
+            >
+              <Bot size={11} />
+              Open Agent operations
+            </Button>
+          )}
         </div>
+        {exploreNext.kind === "NEEDS_SETUP" && (
+          <div className="inline-alert" role="status">
+            <CircleOff size={14} />
+            <span>
+              Scout needs the existing Codex or heuristic session in{" "}
+              <a href={exploreNext.href}>Agent operations</a>.
+            </span>
+          </div>
+        )}
 
         <div className="ai-runtime-panel">
           <div className="ai-runtime-panel-heading">

--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -5953,7 +5953,6 @@ function Overview({
   const catalogObservation = studioProjection.ai.catalogObservation;
   const discoveryExecution = useDiscoveryExecutionCapability();
   const exploreNext = systemExploreNextAction({
-    workers: studioProjection.ai.workers,
     dispatchEligibility:
       discoveryExecution.data?.capability.dispatchEligibility ?? null,
   });

--- a/apps/studio/src/lib/system-explore-next.test.ts
+++ b/apps/studio/src/lib/system-explore-next.test.ts
@@ -3,66 +3,25 @@ import { describe, expect, it } from "vitest";
 import { systemExploreNextAction } from "./system-explore-next.js";
 import { serializeWorkspaceRoute } from "./workspace-route.js";
 
-const heuristicReady = Object.freeze({
-  kind: "HEURISTIC" as const,
-  status: "READY" as const,
-});
-const modelNeedsKey = Object.freeze({
-  kind: "MODEL" as const,
-  status: "NEEDS_KEY" as const,
-});
-const modelReady = Object.freeze({
-  kind: "MODEL" as const,
-  status: "READY" as const,
-});
-
 describe("system overview Explore next", () => {
-  it("keeps Explore next when the routed discovery profile can dispatch", () => {
+  it("keeps Explore next only when discovery can dispatch", () => {
     expect(systemExploreNextAction({
-      workers: [heuristicReady, modelReady],
       dispatchEligibility: "ELIGIBLE",
     })).toEqual({ kind: "SCOUT", label: "Explore next" });
   });
 
-  it("labels the remaining heuristic-only path when the model lane needs a key", () => {
+  it("does not keep a clickable scout when dispatch is blocked or unknown", () => {
     expect(systemExploreNextAction({
-      workers: [heuristicReady, modelNeedsKey],
-      dispatchEligibility: "BLOCKED",
-    })).toEqual({ kind: "SCOUT", label: "Explore next · heuristic" });
-    expect(systemExploreNextAction({
-      workers: [heuristicReady, modelNeedsKey],
-      dispatchEligibility: null,
-    })).toEqual({ kind: "SCOUT", label: "Explore next · heuristic" });
-  });
-
-  it("does not keep a green Explore next when the model looks ready but cannot dispatch", () => {
-    expect(systemExploreNextAction({
-      workers: [heuristicReady, modelReady],
       dispatchEligibility: "BLOCKED",
     })).toEqual({
       kind: "NEEDS_SETUP",
       href: serializeWorkspaceRoute("agents"),
     });
     expect(systemExploreNextAction({
-      workers: [modelReady],
       dispatchEligibility: null,
     })).toEqual({
       kind: "NEEDS_SETUP",
       href: "?view=agents",
     });
-  });
-
-  it("points at Agent operations when no honest scout path exists", () => {
-    expect(systemExploreNextAction({
-      workers: [modelNeedsKey],
-      dispatchEligibility: "BLOCKED",
-    })).toEqual({
-      kind: "NEEDS_SETUP",
-      href: "?view=agents",
-    });
-    expect(systemExploreNextAction({
-      workers: [],
-      dispatchEligibility: null,
-    }).kind).toBe("NEEDS_SETUP");
   });
 });

--- a/apps/studio/src/lib/system-explore-next.test.ts
+++ b/apps/studio/src/lib/system-explore-next.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { systemExploreNextAction } from "./system-explore-next.js";
+import { serializeWorkspaceRoute } from "./workspace-route.js";
+
+const heuristicReady = Object.freeze({
+  kind: "HEURISTIC" as const,
+  status: "READY" as const,
+});
+const modelNeedsKey = Object.freeze({
+  kind: "MODEL" as const,
+  status: "NEEDS_KEY" as const,
+});
+const modelReady = Object.freeze({
+  kind: "MODEL" as const,
+  status: "READY" as const,
+});
+
+describe("system overview Explore next", () => {
+  it("keeps Explore next when the routed discovery profile can dispatch", () => {
+    expect(systemExploreNextAction({
+      workers: [heuristicReady, modelReady],
+      dispatchEligibility: "ELIGIBLE",
+    })).toEqual({ kind: "SCOUT", label: "Explore next" });
+  });
+
+  it("labels the remaining heuristic-only path when the model lane needs a key", () => {
+    expect(systemExploreNextAction({
+      workers: [heuristicReady, modelNeedsKey],
+      dispatchEligibility: "BLOCKED",
+    })).toEqual({ kind: "SCOUT", label: "Explore next · heuristic" });
+    expect(systemExploreNextAction({
+      workers: [heuristicReady, modelNeedsKey],
+      dispatchEligibility: null,
+    })).toEqual({ kind: "SCOUT", label: "Explore next · heuristic" });
+  });
+
+  it("does not keep a green Explore next when the model looks ready but cannot dispatch", () => {
+    expect(systemExploreNextAction({
+      workers: [heuristicReady, modelReady],
+      dispatchEligibility: "BLOCKED",
+    })).toEqual({
+      kind: "NEEDS_SETUP",
+      href: serializeWorkspaceRoute("agents"),
+    });
+    expect(systemExploreNextAction({
+      workers: [modelReady],
+      dispatchEligibility: null,
+    })).toEqual({
+      kind: "NEEDS_SETUP",
+      href: "?view=agents",
+    });
+  });
+
+  it("points at Agent operations when no honest scout path exists", () => {
+    expect(systemExploreNextAction({
+      workers: [modelNeedsKey],
+      dispatchEligibility: "BLOCKED",
+    })).toEqual({
+      kind: "NEEDS_SETUP",
+      href: "?view=agents",
+    });
+    expect(systemExploreNextAction({
+      workers: [],
+      dispatchEligibility: null,
+    }).kind).toBe("NEEDS_SETUP");
+  });
+});

--- a/apps/studio/src/lib/system-explore-next.ts
+++ b/apps/studio/src/lib/system-explore-next.ts
@@ -1,0 +1,48 @@
+import { serializeWorkspaceRoute } from "./workspace-route.js";
+
+export type SystemExploreWorker = Readonly<{
+  kind: "HEURISTIC" | "MODEL";
+  status: "READY" | "NEEDS_KEY" | "NEEDS_PROVIDER";
+}>;
+
+export type SystemExploreNextAction = Readonly<
+  | { kind: "SCOUT"; label: "Explore next" | "Explore next · heuristic" }
+  | { kind: "NEEDS_SETUP"; href: string }
+>;
+
+export function systemExploreNextAction(input: {
+  readonly workers: readonly SystemExploreWorker[];
+  readonly dispatchEligibility: "ELIGIBLE" | "BLOCKED" | null;
+}): SystemExploreNextAction {
+  const heuristicReady = input.workers.some(
+    (worker) => worker.kind === "HEURISTIC" && worker.status === "READY",
+  );
+  const modelReady = input.workers.some(
+    (worker) => worker.kind === "MODEL" && worker.status === "READY",
+  );
+
+  if (input.dispatchEligibility === "ELIGIBLE") {
+    return Object.freeze({ kind: "SCOUT", label: "Explore next" as const });
+  }
+
+  // A model worker can appear READY while Codex dispatch is still blocked.
+  // The lease refuses that path, so do not keep a green Explore next.
+  if (modelReady) {
+    return Object.freeze({
+      kind: "NEEDS_SETUP",
+      href: serializeWorkspaceRoute("agents"),
+    });
+  }
+
+  if (heuristicReady) {
+    return Object.freeze({
+      kind: "SCOUT",
+      label: "Explore next · heuristic" as const,
+    });
+  }
+
+  return Object.freeze({
+    kind: "NEEDS_SETUP",
+    href: serializeWorkspaceRoute("agents"),
+  });
+}

--- a/apps/studio/src/lib/system-explore-next.ts
+++ b/apps/studio/src/lib/system-explore-next.ts
@@ -1,46 +1,19 @@
 import { serializeWorkspaceRoute } from "./workspace-route.js";
 
-export type SystemExploreWorker = Readonly<{
-  kind: "HEURISTIC" | "MODEL";
-  status: "READY" | "NEEDS_KEY" | "NEEDS_PROVIDER";
-}>;
-
 export type SystemExploreNextAction = Readonly<
-  | { kind: "SCOUT"; label: "Explore next" | "Explore next · heuristic" }
+  | { kind: "SCOUT"; label: "Explore next" }
   | { kind: "NEEDS_SETUP"; href: string }
 >;
 
 export function systemExploreNextAction(input: {
-  readonly workers: readonly SystemExploreWorker[];
   readonly dispatchEligibility: "ELIGIBLE" | "BLOCKED" | null;
 }): SystemExploreNextAction {
-  const heuristicReady = input.workers.some(
-    (worker) => worker.kind === "HEURISTIC" && worker.status === "READY",
-  );
-  const modelReady = input.workers.some(
-    (worker) => worker.kind === "MODEL" && worker.status === "READY",
-  );
-
+  // Search leases always requireDispatchEligible. There is no Studio path
+  // that runs heuristic-fast-1 without that gate, so a heuristic suffix
+  // would still call runScout and bounce.
   if (input.dispatchEligibility === "ELIGIBLE") {
     return Object.freeze({ kind: "SCOUT", label: "Explore next" as const });
   }
-
-  // A model worker can appear READY while Codex dispatch is still blocked.
-  // The lease refuses that path, so do not keep a green Explore next.
-  if (modelReady) {
-    return Object.freeze({
-      kind: "NEEDS_SETUP",
-      href: serializeWorkspaceRoute("agents"),
-    });
-  }
-
-  if (heuristicReady) {
-    return Object.freeze({
-      kind: "SCOUT",
-      label: "Explore next · heuristic" as const,
-    });
-  }
-
   return Object.freeze({
     kind: "NEEDS_SETUP",
     href: serializeWorkspaceRoute("agents"),

--- a/apps/studio/src/product-shell.css
+++ b/apps/studio/src/product-shell.css
@@ -3604,6 +3604,12 @@ footer {
   font-size: 13px;
 }
 
+.inline-alert a {
+  color: inherit;
+  font-weight: 650;
+  text-decoration: underline;
+}
+
 @media (max-width: 900px) {
   .agent-console-grid,
   .agent-control-form,


### PR DESCRIPTION
Fixes #28

Independent of #14 / #26 / #27. This PR is a new branch from `origin/main` only. Those issues stay pressed.

## What changed

On `?view=system`, **Explore next** stayed green and called `runScout` whenever it was not already running — even when `model-fast-lane` was **NEEDS_KEY** and Discover/Findings already withheld their next click.

The button now follows the same honesty rule:

- Codex dispatch **ELIGIBLE** → **Explore next** (unchanged scout)
- Model lane blocked, heuristic worker **READY** → **Explore next · heuristic**
- No honest scout path → outline **Open Agent operations** plus a line pointing at the existing Codex / heuristic session

No spend, signing, funds, or OAuth wizard was added.

## How to check

1. Open Studio at `/?view=system` with the model lane **NEEDS_KEY** (do not start a scout if the button is gone).
2. If heuristic-fast-1 is READY, the primary action should read **Explore next · heuristic**, not a plain green **Explore next**.
3. If no heuristic worker is ready either, the primary action should be **Open Agent operations** and should not call `runScout`.
4. Sidebar remains **Analysis only · no execution**.

## Tests

- `apps/studio/src/lib/system-explore-next.test.ts` — ELIGIBLE keeps Explore next; NEEDS_KEY + heuristic READY labels heuristic; no honest path retargets to Agent operations