### PR TITLE
Stop calling catalog listingCount markets next to Markets

### DIFF
--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -71,6 +71,7 @@ import {
   type StandingRouteUsage,
 } from "@/data/standing-routes";
 import { cn } from "@/lib/utils";
+import { marketsWorkspaceCopy } from "@/lib/markets-workspace-copy";
 import {
   parseWorkspaceRoute,
   serializeWorkspaceRoute,
@@ -3892,15 +3893,18 @@ async function requestCandidateWatchRefresh(): Promise<"READY" | "DEGRADED"> {
 function SidebarStatus() {
   const studioProjection = useStudioProjection();
   const observation = studioProjection.ai.catalogObservation;
+  const copy = marketsWorkspaceCopy({
+    healthySourceCount: observation.healthySourceCount,
+    sourceCount: observation.sourceCount,
+    listingCount: observation.listingCount,
+    venueAdapterCount: studioProjection.venues.length,
+  });
   return (
     <div className="sidebar-status">
       <span className="sidebar-status-dot" />
       <div>
         <strong>System ready</strong>
-        <span>
-          {observation.healthySourceCount}/{observation.sourceCount} sources ·{" "}
-          {observation.listingCount} markets
-        </span>
+        <span>{copy.sidebarCatalogLine}</span>
       </div>
     </div>
   );
@@ -12752,15 +12756,19 @@ function ResearchCaseDeskView() {
 
 function VenueMatrix() {
   const studioProjection = useStudioProjection();
+  const observation = studioProjection.ai.catalogObservation;
+  const copy = marketsWorkspaceCopy({
+    healthySourceCount: observation.healthySourceCount,
+    sourceCount: observation.sourceCount,
+    listingCount: observation.listingCount,
+    venueAdapterCount: studioProjection.venues.length,
+  });
   return (
     <section className="page-section">
       <div className="page-heading">
         <span className="eyebrow">Protocol reality</span>
-        <h1>Venue capability matrix</h1>
-        <p>
-          Each adapter owns its precision, authentication boundary, mechanism,
-          and qualification evidence.
-        </p>
+        <h1>{copy.pageTitle}</h1>
+        <p>{copy.pageDescription}</p>
       </div>
       <div className="venue-grid">
         {studioProjection.venues.map((venue) => (

--- a/apps/studio/src/lib/markets-workspace-copy.test.ts
+++ b/apps/studio/src/lib/markets-workspace-copy.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { marketsWorkspaceCopy } from "./markets-workspace-copy.js";
+
+const observed = {
+  healthySourceCount: 5,
+  sourceCount: 7,
+  listingCount: 580,
+  venueAdapterCount: 7,
+} as const;
+
+describe("marketsWorkspaceCopy", () => {
+  it("does not call catalog listingCount markets next to the Markets venue matrix", () => {
+    const copy = marketsWorkspaceCopy(observed);
+    expect(copy.sidebarCatalogLine).toBe("5/7 sources · 580 listings");
+    expect(copy.sidebarCatalogLine.toLowerCase()).not.toContain("market");
+    expect(copy.pageTitle).toBe("Venue capability matrix");
+    expect(copy.pageDescription).toContain("7 venue adapters");
+    expect(copy.pageDescription).toContain("580 listings");
+    expect(copy.pageDescription).toContain("not a listing browser");
+  });
+
+  it("uses the same listing count on the Markets page as in the sidebar", () => {
+    const copy = marketsWorkspaceCopy({
+      ...observed,
+      listingCount: 1,
+      venueAdapterCount: 1,
+    });
+    expect(copy.sidebarCatalogLine).toBe("5/7 sources · 1 listing");
+    expect(copy.pageDescription).toContain("1 venue adapter");
+    expect(copy.pageDescription).toContain("1 listing");
+    expect(copy.pageDescription).not.toMatch(/market/i);
+  });
+});

--- a/apps/studio/src/lib/markets-workspace-copy.ts
+++ b/apps/studio/src/lib/markets-workspace-copy.ts
@@ -1,0 +1,35 @@
+export type MarketsWorkspaceCounts = Readonly<{
+  healthySourceCount: number;
+  sourceCount: number;
+  listingCount: number;
+  venueAdapterCount: number;
+}>;
+
+export type MarketsWorkspaceCopy = Readonly<{
+  sidebarCatalogLine: string;
+  pageTitle: string;
+  pageDescription: string;
+}>;
+
+export const MARKETS_PAGE_TITLE = "Venue capability matrix";
+
+export function marketsWorkspaceCopy(
+  counts: MarketsWorkspaceCounts,
+): MarketsWorkspaceCopy {
+  const listings = countPhrase(counts.listingCount, "listing", "listings");
+  const adapters = countPhrase(
+    counts.venueAdapterCount,
+    "venue adapter",
+    "venue adapters",
+  );
+  return {
+    sidebarCatalogLine: `${counts.healthySourceCount}/${counts.sourceCount} sources · ${listings}`,
+    pageTitle: MARKETS_PAGE_TITLE,
+    pageDescription:
+      `These are ${adapters}, not a listing browser. The catalog currently holds ${listings}. Each adapter owns its precision, authentication boundary, mechanism, and qualification evidence.`,
+  };
+}
+
+function countPhrase(count: number, singular: string, plural: string): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}


### PR DESCRIPTION
Fixes #26

Independent of #14 / #27 / #28 / #29 / #30. This PR is a new branch from `origin/main` only. Those issues stay pressed.

## What changed

Sidebar **System ready** said **5/7 sources · 580 markets** from `catalogObservation.listingCount`, while `?view=markets` is seven venue-capability cards with no listing list.

The sidebar now says **listings**. The Markets page still titles **Venue capability matrix** and now says these are venue adapters, how many listings the catalog currently holds, and that it is not a listing browser. No catalog UI, order, trade, or spend path was added.

## How to check

1. Open Studio at `/?view=markets` (do not enable trading).
2. Sidebar should read **N/M sources · K listings**, not **markets**.
3. The page should still be seven venue cards, and the lede should mention venue adapters plus the same listing count.
4. Sidebar remains **Analysis only · no execution**.

## Tests

- `apps/studio/src/lib/markets-workspace-copy.test.ts` — 580 listings / 7 adapters; singular forms; no "market" in the new lines