### PR TITLE
Disable Discover Run now when discovery cannot dispatch

### DIFF
--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -71,6 +71,7 @@ import {
   type StandingRouteUsage,
 } from "@/data/standing-routes";
 import { cn } from "@/lib/utils";
+import { searchIssueRunNow } from "@/lib/search-issue-run-now";
 import {
   parseWorkspaceRoute,
   serializeWorkspaceRoute,
@@ -7058,6 +7059,9 @@ function MarketArchaeologistView() {
   const discoveryCapability = discoveryExecution.data?.capability;
   const discoveryRuntime = discoveryExecution.data?.runtime;
   const discoveryModel = discoveryExecution.data?.model;
+  const searchIssueRun = searchIssueRunNow({
+    dispatchEligibility: discoveryCapability?.dispatchEligibility ?? null,
+  });
   const currentLensRecords = scheduler.records.filter(
     (record) => record.lease.snapshotIdentity === corpus.snapshotIdentity,
   );
@@ -7756,7 +7760,8 @@ function MarketArchaeologistView() {
                         variant="outline"
                         disabled={
                           corpus.listingCount === 0 || issueAction !== null ||
-                          (issue.supersededByIssueId !== undefined && issue.supersededByIssueId !== null)
+                          (issue.supersededByIssueId !== undefined && issue.supersededByIssueId !== null) ||
+                          !searchIssueRun.dispatchEligible
                         }
                         onClick={() => void runIssue(issue.issueId)}
                       >
@@ -7852,7 +7857,7 @@ function MarketArchaeologistView() {
           </form>
           {!issueScheduler.enabled && (
             <p className="issue-scheduler-hint">
-              Automatic dispatch is installed but intentionally explicit. Set <code>PMH_SEARCH_ISSUE_TICK_MS</code> to 1000–60000 and restart the control plane; manual runs work now.
+              {searchIssueRun.schedulerHint}
             </p>
           )}
           {issueDiagnostic !== null && (

--- a/apps/studio/src/lib/search-issue-run-now.test.ts
+++ b/apps/studio/src/lib/search-issue-run-now.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { searchIssueRunNow } from "./search-issue-run-now.js";
+
+describe("search issue Run now", () => {
+  it("allows Run now only when discovery can dispatch", () => {
+    expect(searchIssueRunNow({
+      dispatchEligibility: "ELIGIBLE",
+    })).toEqual({
+      dispatchEligible: true,
+      schedulerHint:
+        "Automatic dispatch is installed but intentionally explicit. Set PMH_SEARCH_ISSUE_TICK_MS to 1000–60000 and restart the control plane; manual runs work now.",
+    });
+  });
+
+  it("does not claim manual runs work when dispatch is blocked or unknown", () => {
+    for (const dispatchEligibility of ["BLOCKED", null] as const) {
+      const result = searchIssueRunNow({ dispatchEligibility });
+      expect(result.dispatchEligible).toBe(false);
+      expect(result.schedulerHint).toBe(
+        "Automatic dispatch is installed but intentionally explicit. Manual Run now stays blocked until discovery can dispatch.",
+      );
+      expect(result.schedulerHint.toLowerCase()).not.toContain("manual runs work now");
+      expect(result.schedulerHint).not.toContain("PMH_SEARCH_ISSUE_TICK_MS");
+    }
+  });
+});

--- a/apps/studio/src/lib/search-issue-run-now.ts
+++ b/apps/studio/src/lib/search-issue-run-now.ts
@@ -1,0 +1,18 @@
+export type SearchIssueRunNow = Readonly<{
+  dispatchEligible: boolean;
+  schedulerHint: string;
+}>;
+
+export function searchIssueRunNow(input: {
+  readonly dispatchEligibility: "ELIGIBLE" | "BLOCKED" | null;
+}): SearchIssueRunNow {
+  // POST /api/v1/search-issues/:id/runs spends the discovery route, same as
+  // the hero scan. Pause/resume is local via requestSearchIssueEnabled.
+  const dispatchEligible = input.dispatchEligibility === "ELIGIBLE";
+  return Object.freeze({
+    dispatchEligible,
+    schedulerHint: dispatchEligible
+      ? "Automatic dispatch is installed but intentionally explicit. Set PMH_SEARCH_ISSUE_TICK_MS to 1000–60000 and restart the control plane; manual runs work now."
+      : "Automatic dispatch is installed but intentionally explicit. Manual Run now stays blocked until discovery can dispatch.",
+  });
+}


### PR DESCRIPTION
Fixes #30

Independent of #14 / #27 / #32–#35. This PR is a new branch from `origin/main` only. Those issues stay pressed.

## What changed

Discover Search operations **Run now** (`requestSearchIssueRun` → `POST /api/v1/search-issues/:id/runs`) was only disabled for an empty corpus, an in-flight action, or a superseded issue. The hero **Start heuristic scan** was already greyed when `dispatchEligibility !== "ELIGIBLE"`.

**Run now** now uses the same gate. **Pause / Resume** stays local and enabled. The scheduler hint no longer says "manual runs work now" when dispatch is blocked. Automatic `PMH_SEARCH_ISSUE_TICK_MS` stays off. No new spend path.

## How to check

1. Open Studio at `/?view=discover` with no key (do not enable trading, do not click Run now while it is still armed on main).
2. Hero **Start heuristic scan** and each brief **Run now** should both be grey.
3. **Pause** should still work.
4. The Search operations hint should not say manual runs work.
5. Sidebar remains **Analysis only · no execution**.

## Tests

- `apps/studio/src/lib/search-issue-run-now.test.ts` — ELIGIBLE keeps Run now; BLOCKED / unknown disable it and drop the "manual runs work now" claim