### PR TITLE
Show execution profile identity on Agents capability rows

### DIFF
--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -70,6 +70,7 @@ import {
   type StandingRouteState,
   type StandingRouteUsage,
 } from "@/data/standing-routes";
+import { executionProfileRowIdentity } from "@/lib/execution-profile-row-identity";
 import { cn } from "@/lib/utils";
 import {
   parseWorkspaceRoute,
@@ -5790,6 +5791,7 @@ function AgentOperationsView() {
                 <div className="agent-runtime-row" key={`capability:${profile.executionProfileId}`}>
                   <div>
                     <strong>{runtime?.kind ?? "runtime"} · {model?.model ?? "model"}</strong>
+                    <span>{executionProfileRowIdentity(profile)}</span>
                     <span>{capability?.serviceCapability ?? "UNVERIFIED"} · {capability?.diagnostic ?? "not checked"}</span>
                   </div>
                   <Button
@@ -5845,7 +5847,7 @@ function AgentOperationsView() {
             <label><span>Execution profile</span><Select value={profileId} onValueChange={(value) => { setProfileId(value); setManualPreview(null); }}><SelectTrigger><SelectValue placeholder="Select profile" /></SelectTrigger><SelectContent>{profiles.map((profile) => {
               const runtime = runtimes.get(profile.runtimeDefinitionId);
               const model = models.get(profile.modelProfileId);
-              return <SelectItem key={profile.executionProfileId} value={profile.executionProfileId}>{runtime?.kind ?? "runtime"} · {model?.model ?? "model"} · r{profile.revision}</SelectItem>;
+              return <SelectItem key={profile.executionProfileId} value={profile.executionProfileId}>{runtime?.kind ?? "runtime"} · {model?.model ?? "model"} · {executionProfileRowIdentity(profile)}</SelectItem>;
             })}</SelectContent></Select></label>
           </div>
           <div className="agent-control-actions">

--- a/apps/studio/src/lib/execution-profile-row-identity.test.ts
+++ b/apps/studio/src/lib/execution-profile-row-identity.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { executionProfileRowIdentity } from "./execution-profile-row-identity.js";
+
+const terraCodex = {
+  executionProfileId: `sha256:${"a".repeat(64)}`,
+  profileKey: "rule-evidence-codex-app-server",
+  revision: 1006,
+} as const;
+
+const terraOntology = {
+  executionProfileId: `sha256:${"b".repeat(64)}`,
+  profileKey: "ontology-codex-app-server",
+  revision: 1002,
+} as const;
+
+describe("execution profile row identity", () => {
+  it("shows the picker rN plus profileKey and a short id", () => {
+    expect(executionProfileRowIdentity(terraCodex)).toBe(
+      "r1006 · rule-evidence-codex-app-server · aaaaaaaaaa",
+    );
+  });
+
+  it("distinguishes same-runtime same-model rows the picker would otherwise collapse", () => {
+    const left = executionProfileRowIdentity(terraCodex);
+    const right = executionProfileRowIdentity(terraOntology);
+    expect(left).not.toBe(right);
+    expect(left).toContain("r1006");
+    expect(right).toContain("r1002");
+    expect(left).toContain("rule-evidence-codex-app-server");
+    expect(right).toContain("ontology-codex-app-server");
+    expect(left).toContain("aaaaaaaaaa");
+    expect(right).toContain("bbbbbbbbbb");
+  });
+
+  it("keeps later revisions of the same profileKey distinct", () => {
+    expect(executionProfileRowIdentity({
+      ...terraCodex,
+      executionProfileId: `sha256:${"c".repeat(64)}`,
+      revision: 2006,
+    })).toBe("r2006 · rule-evidence-codex-app-server · cccccccccc");
+  });
+
+  it("does not turn the capability list into a run or campaign control", () => {
+    const label = executionProfileRowIdentity(terraCodex).toLowerCase();
+    expect(label).not.toContain("preflight");
+    expect(label).not.toContain("run");
+    expect(label).not.toContain("campaign");
+    expect(label).not.toContain("spend");
+  });
+});

--- a/apps/studio/src/lib/execution-profile-row-identity.ts
+++ b/apps/studio/src/lib/execution-profile-row-identity.ts
@@ -1,0 +1,20 @@
+const HASH_PREFIX = "sha256:";
+const SHORT_ID_LENGTH = 10;
+
+export type ExecutionProfileRowIdentityInput = Readonly<{
+  executionProfileId: string;
+  profileKey: string;
+  revision: number;
+}>;
+
+function shortExecutionProfileId(executionProfileId: string): string {
+  return executionProfileId.startsWith(HASH_PREFIX)
+    ? executionProfileId.slice(HASH_PREFIX.length, HASH_PREFIX.length + SHORT_ID_LENGTH)
+    : executionProfileId.slice(0, SHORT_ID_LENGTH);
+}
+
+export function executionProfileRowIdentity(
+  profile: ExecutionProfileRowIdentityInput,
+): string {
+  return `r${profile.revision} · ${profile.profileKey} · ${shortExecutionProfileId(profile.executionProfileId)}`;
+}


### PR DESCRIPTION
Fixes #32

Independent of #14 / #20 / #27 / #30 / #33–#35 / #37. This PR is a new branch from `origin/main` only. Those issues stay pressed.

## What changed

Agents **Execution capability** listed only `runtime · model`, so ~42 `CODEX · gpt-5.6-terra` rows were indistinguishable. Each row now shows the same `rN` the Prepare work picker already had, plus `profileKey` and a short `executionProfileId`. The picker uses the same identity string.

Preflight stays a per-row recheck. No run, campaign, or spend path was added. The Tasks / runs tile is untouched (#20).

## How to check

1. Open Studio at `/?view=agents` (do not enable trading, do not start a run).
2. Each Execution capability profile row should show `rN · <profileKey> · <short id>` under the runtime · model line.
3. The Prepare work profile picker should use that same identity.
4. Two same-model rows must remain distinguishable.
5. Sidebar remains **Analysis only · no execution**.

## Tests

- `apps/studio/src/lib/execution-profile-row-identity.test.ts` — rN + profileKey + short id; same-model rows stay distinct; later revisions stay distinct