### PR TITLE
Scope Preflight stage circle to the step index only

### DIFF
--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -6889,7 +6889,7 @@ function RealCandidatePreflightView() {
           <CardContent className="preflight-stage-list">
             {currentStages.map((stage, index) => (
               <div className="preflight-stage" key={stage.stage}>
-                <span className={stage.status === "PASS" ? "" : "is-blocked"}>
+                <span className={stage.status === "PASS" ? "preflight-stage-index" : "preflight-stage-index is-blocked"}>
                   {stage.status === "PASS" ? index + 1 : <CircleOff size={11} />}
                 </span>
                 <div>

--- a/apps/studio/src/index.css
+++ b/apps/studio/src/index.css
@@ -6006,7 +6006,7 @@ footer span:first-child {
   padding-bottom: 0;
 }
 
-.preflight-stage > span {
+.preflight-stage-index {
   display: grid;
   width: 22px;
   height: 22px;
@@ -6018,7 +6018,7 @@ footer span:first-child {
   font-size: 12px;
 }
 
-.preflight-stage > span.is-blocked {
+.preflight-stage-index.is-blocked {
   border-color: rgba(213, 161, 110, 0.18);
   color: #d5a16e;
 }

--- a/apps/studio/src/lib/preflight-stage-index.test.ts
+++ b/apps/studio/src/lib/preflight-stage-index.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const studioRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("preflight stage index circle", () => {
+  it("scopes the 22px circle to the step index, not every child span", () => {
+    const css = readFileSync(join(studioRoot, "index.css"), "utf8");
+    expect(css).toContain(".preflight-stage-index {");
+    expect(css).toContain("width: 22px;");
+    expect(css).not.toMatch(/\.preflight-stage\s*>\s*span\s*\{/);
+  });
+
+  it("marks the step index with preflight-stage-index so Badge stays a pill", () => {
+    const app = readFileSync(join(studioRoot, "App.tsx"), "utf8");
+    expect(app).toContain('className={stage.status === "PASS" ? "preflight-stage-index" : "preflight-stage-index is-blocked"}');
+    expect(app).toContain("<Badge variant={stage.status === \"PASS\" ? \"verified\" : \"shadow\"}>");
+  });
+});


### PR DESCRIPTION
Fixes #37

Independent of #14 / #27 / #32–#35. This PR is a new branch from `origin/main` only. Those issues stay pressed.

## What changed

Preflight **Where the candidate stops** used `.preflight-stage > span` for the 22px step-index circle. `Badge` is also a `<span>`, so PASS / REJECTED / NOT_RUN were crushed into that circle (PA / REJEC / NOT_R).

The circle is now scoped to `.preflight-stage-index` on the step index only. The verdict Badge stays a normal pill. No decision, spend, or trading change.

Not #34 (raw gross floor) and not #35 (certificate drawer vertical clip).

## How to check

1. Open Studio at `/?view=preflight` (do not enable trading).
2. Under **Where the candidate stops**, step numbers stay 22px circles.
3. PASS / REJECTED / NOT_RUN badges must be full readable pills, not truncated circles.
4. Sidebar remains **Analysis only · no execution**.

## Tests

- `apps/studio/src/lib/preflight-stage-index.test.ts` — CSS no longer uses `.preflight-stage > span`; App marks the index with `preflight-stage-index`