### PR TITLE
Let Preflight post-fee upper bound show its full name

### DIFF
--- a/apps/studio/src/index.css
+++ b/apps/studio/src/index.css
@@ -5506,22 +5506,24 @@ footer span:first-child {
 .preflight-disposition-facts span,
 .preflight-disposition-facts strong {
   display: block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .preflight-disposition-facts span {
   color: #685c51;
   font-size: 12px;
   text-transform: uppercase;
+  overflow: visible;
+  white-space: normal;
 }
 
 .preflight-disposition-facts strong {
   margin-top: 5px;
+  overflow: hidden;
   color: #c28f62;
   font-family: inherit;
   font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .preflight-disposition > code {

--- a/apps/studio/src/lib/preflight-disposition-facts.test.ts
+++ b/apps/studio/src/lib/preflight-disposition-facts.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const studioRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("preflight disposition fact labels", () => {
+  it("does not ellipsize POST-FEE UPPER BOUND", () => {
+    const css = readFileSync(join(studioRoot, "index.css"), "utf8");
+    const start = css.indexOf(".preflight-disposition-facts span {");
+    expect(start).toBeGreaterThan(-1);
+    const block = css.slice(start, css.indexOf("}", start) + 1);
+    expect(block).toContain("white-space: normal");
+    expect(block).not.toContain("ellipsis");
+    expect(block).not.toContain("nowrap");
+  });
+
+  it("keeps the Post-fee upper bound copy on the current-snapshot row", () => {
+    const app = readFileSync(join(studioRoot, "App.tsx"), "utf8");
+    expect(app).toContain("<span>Post-fee upper bound</span>");
+    expect(app).toContain("className=\"preflight-disposition-facts\"");
+  });
+});


### PR DESCRIPTION
Fixes #40

Independent of #14 / #27 / #33–#35 / #37. This PR is a new branch from `origin/main` only. Those issues stay pressed.

## What changed

The current-snapshot disposition row ellipsized **POST-FEE UPPER BOUND** to **POST-FEE UPPER BO...** because fact labels shared `nowrap` + `ellipsis` on three equal columns. The `0.0000` cell then had no readable name.

Fact labels wrap and stay complete. Values can still ellipsize. The number itself is unchanged (not #34). No spend or trading change.

Not #35 (certificate drawer) and not #37 (step-index circle).

## How to check

1. Open Studio at `/?view=preflight` (do not enable trading). 5173/4100 stay untouched; look-only on 4220 is fine.
2. On the current-snapshot disposition row, **POST-FEE UPPER BOUND** must be readable in full.
3. **SELL TAKER RANGE** and **NEW BOOKS** stay complete.
4. Sidebar remains **Analysis only · no execution**.

## Tests

- `apps/studio/src/lib/preflight-disposition-facts.test.ts` — fact-label CSS no longer nowrap/ellipsis; copy stays `Post-fee upper bound`