### PR TITLE
Agents and Preflight chrome

### DIFF
--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -6891,7 +6891,7 @@ function RealCandidatePreflightView() {
           <CardContent className="preflight-stage-list">
             {currentStages.map((stage, index) => (
               <div className="preflight-stage" key={stage.stage}>
-                <span className={stage.status === "PASS" ? "" : "is-blocked"}>
+                <span className={stage.status === "PASS" ? "preflight-stage-index" : "preflight-stage-index is-blocked"}>
                   {stage.status === "PASS" ? index + 1 : <CircleOff size={11} />}
                 </span>
                 <div>

--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -70,6 +70,7 @@ import {
   type StandingRouteState,
   type StandingRouteUsage,
 } from "@/data/standing-routes";
+import { executionProfileRowIdentity } from "@/lib/execution-profile-row-identity";
 import { cn } from "@/lib/utils";
 import {
   parseWorkspaceRoute,
@@ -5790,6 +5791,7 @@ function AgentOperationsView() {
                 <div className="agent-runtime-row" key={`capability:${profile.executionProfileId}`}>
                   <div>
                     <strong>{runtime?.kind ?? "runtime"} · {model?.model ?? "model"}</strong>
+                    <span>{executionProfileRowIdentity(profile)}</span>
                     <span>{capability?.serviceCapability ?? "UNVERIFIED"} · {capability?.diagnostic ?? "not checked"}</span>
                   </div>
                   <Button
@@ -5845,7 +5847,7 @@ function AgentOperationsView() {
             <label><span>Execution profile</span><Select value={profileId} onValueChange={(value) => { setProfileId(value); setManualPreview(null); }}><SelectTrigger><SelectValue placeholder="Select profile" /></SelectTrigger><SelectContent>{profiles.map((profile) => {
               const runtime = runtimes.get(profile.runtimeDefinitionId);
               const model = models.get(profile.modelProfileId);
-              return <SelectItem key={profile.executionProfileId} value={profile.executionProfileId}>{runtime?.kind ?? "runtime"} · {model?.model ?? "model"} · r{profile.revision}</SelectItem>;
+              return <SelectItem key={profile.executionProfileId} value={profile.executionProfileId}>{runtime?.kind ?? "runtime"} · {model?.model ?? "model"} · {executionProfileRowIdentity(profile)}</SelectItem>;
             })}</SelectContent></Select></label>
           </div>
           <div className="agent-control-actions">

--- a/apps/studio/src/index.css
+++ b/apps/studio/src/index.css
@@ -5506,22 +5506,24 @@ footer span:first-child {
 .preflight-disposition-facts span,
 .preflight-disposition-facts strong {
   display: block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .preflight-disposition-facts span {
   color: #685c51;
   font-size: 12px;
   text-transform: uppercase;
+  overflow: visible;
+  white-space: normal;
 }
 
 .preflight-disposition-facts strong {
   margin-top: 5px;
+  overflow: hidden;
   color: #c28f62;
   font-family: inherit;
   font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .preflight-disposition > code {

--- a/apps/studio/src/index.css
+++ b/apps/studio/src/index.css
@@ -6006,7 +6006,7 @@ footer span:first-child {
   padding-bottom: 0;
 }
 
-.preflight-stage > span {
+.preflight-stage-index {
   display: grid;
   width: 22px;
   height: 22px;
@@ -6018,7 +6018,7 @@ footer span:first-child {
   font-size: 12px;
 }
 
-.preflight-stage > span.is-blocked {
+.preflight-stage-index.is-blocked {
   border-color: rgba(213, 161, 110, 0.18);
   color: #d5a16e;
 }

--- a/apps/studio/src/lib/execution-profile-row-identity.test.ts
+++ b/apps/studio/src/lib/execution-profile-row-identity.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { executionProfileRowIdentity } from "./execution-profile-row-identity.js";
+
+const terraCodex = {
+  executionProfileId: `sha256:${"a".repeat(64)}`,
+  profileKey: "rule-evidence-codex-app-server",
+  revision: 1006,
+} as const;
+
+const terraOntology = {
+  executionProfileId: `sha256:${"b".repeat(64)}`,
+  profileKey: "ontology-codex-app-server",
+  revision: 1002,
+} as const;
+
+describe("execution profile row identity", () => {
+  it("shows the picker rN plus profileKey and a short id", () => {
+    expect(executionProfileRowIdentity(terraCodex)).toBe(
+      "r1006 · rule-evidence-codex-app-server · aaaaaaaaaa",
+    );
+  });
+
+  it("distinguishes same-runtime same-model rows the picker would otherwise collapse", () => {
+    const left = executionProfileRowIdentity(terraCodex);
+    const right = executionProfileRowIdentity(terraOntology);
+    expect(left).not.toBe(right);
+    expect(left).toContain("r1006");
+    expect(right).toContain("r1002");
+    expect(left).toContain("rule-evidence-codex-app-server");
+    expect(right).toContain("ontology-codex-app-server");
+    expect(left).toContain("aaaaaaaaaa");
+    expect(right).toContain("bbbbbbbbbb");
+  });
+
+  it("keeps later revisions of the same profileKey distinct", () => {
+    expect(executionProfileRowIdentity({
+      ...terraCodex,
+      executionProfileId: `sha256:${"c".repeat(64)}`,
+      revision: 2006,
+    })).toBe("r2006 · rule-evidence-codex-app-server · cccccccccc");
+  });
+
+  it("does not turn the capability list into a run or campaign control", () => {
+    const label = executionProfileRowIdentity(terraCodex).toLowerCase();
+    expect(label).not.toContain("preflight");
+    expect(label).not.toContain("run");
+    expect(label).not.toContain("campaign");
+    expect(label).not.toContain("spend");
+  });
+});

--- a/apps/studio/src/lib/execution-profile-row-identity.ts
+++ b/apps/studio/src/lib/execution-profile-row-identity.ts
@@ -1,0 +1,20 @@
+const HASH_PREFIX = "sha256:";
+const SHORT_ID_LENGTH = 10;
+
+export type ExecutionProfileRowIdentityInput = Readonly<{
+  executionProfileId: string;
+  profileKey: string;
+  revision: number;
+}>;
+
+function shortExecutionProfileId(executionProfileId: string): string {
+  return executionProfileId.startsWith(HASH_PREFIX)
+    ? executionProfileId.slice(HASH_PREFIX.length, HASH_PREFIX.length + SHORT_ID_LENGTH)
+    : executionProfileId.slice(0, SHORT_ID_LENGTH);
+}
+
+export function executionProfileRowIdentity(
+  profile: ExecutionProfileRowIdentityInput,
+): string {
+  return `r${profile.revision} · ${profile.profileKey} · ${shortExecutionProfileId(profile.executionProfileId)}`;
+}

--- a/apps/studio/src/lib/preflight-disposition-facts.test.ts
+++ b/apps/studio/src/lib/preflight-disposition-facts.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const studioRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("preflight disposition fact labels", () => {
+  it("does not ellipsize POST-FEE UPPER BOUND", () => {
+    const css = readFileSync(join(studioRoot, "index.css"), "utf8");
+    const start = css.indexOf(".preflight-disposition-facts span {");
+    expect(start).toBeGreaterThan(-1);
+    const block = css.slice(start, css.indexOf("}", start) + 1);
+    expect(block).toContain("white-space: normal");
+    expect(block).not.toContain("ellipsis");
+    expect(block).not.toContain("nowrap");
+  });
+
+  it("keeps the Post-fee upper bound copy on the current-snapshot row", () => {
+    const app = readFileSync(join(studioRoot, "App.tsx"), "utf8");
+    expect(app).toContain("<span>Post-fee upper bound</span>");
+    expect(app).toContain("className=\"preflight-disposition-facts\"");
+  });
+});

--- a/apps/studio/src/lib/preflight-stage-index.test.ts
+++ b/apps/studio/src/lib/preflight-stage-index.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const studioRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("preflight stage index circle", () => {
+  it("scopes the 22px circle to the step index, not every child span", () => {
+    const css = readFileSync(join(studioRoot, "index.css"), "utf8");
+    expect(css).toContain(".preflight-stage-index {");
+    expect(css).toContain("width: 22px;");
+    expect(css).not.toMatch(/\.preflight-stage\s*>\s*span\s*\{/);
+  });
+
+  it("marks the step index with preflight-stage-index so Badge stays a pill", () => {
+    const app = readFileSync(join(studioRoot, "App.tsx"), "utf8");
+    expect(app).toContain('className={stage.status === "PASS" ? "preflight-stage-index" : "preflight-stage-index is-blocked"}');
+    expect(app).toContain("<Badge variant={stage.status === \"PASS\" ? \"verified\" : \"shadow\"}>");
+  });
+});


### PR DESCRIPTION
Topic PR. Independent of Books-as-blotter (#14), Fast search Busy (#27), Discover overdue (#33), raw gross floor (#34), and certificate-drawer clip (#35). Those stay pressed and are not in this branch.

## Why this exists

Later play was chrome, not product invention: Agents Execution capability listed ~42 identical `CODEX · gpt-5.6-terra` rows, Preflight stage badges were crushed into the 22px step-index circle, and POST-FEE UPPER BOUND was ellipsized off the 0.0000 cell. One review for the chrome, not three.

This branch is those three fixes from `origin/main`. The 0.0000 value is unchanged (not #34). No orders, signing, or funds. No merge.

## Supersedes

| Small PR | Issue | What it did |
| --- | --- | --- |
| #38 | #32 | Execution capability rows show rN · profileKey · short id |
| #39 | #37 | Preflight stage circle is only on the step index; Badge stays a pill |
| #41 | #40 | POST-FEE UPPER BOUND is readable in full |

Those small PRs will be closed as superseded once this is open.

## How to check

Look-only. Do not enable trading. Do not take 5173 / 4100. Do not start a run or campaign.

1. Open Studio (idle port is fine, e.g. `http://127.0.0.1:4220/`).
2. `/?view=agents` Execution capability rows must be distinguishable (rN / profileKey / short id).
3. `/?view=preflight` **Where the candidate stops** PASS / REJECTED / NOT_RUN must be full pills, not 22px circles.
4. Current-snapshot **POST-FEE UPPER BOUND** must be readable next to 0.0000.
5. Sidebar remains **Analysis only · no execution**.