### PR TITLE
Desk copy and dispatch honesty

### DIFF
--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Activity,
   BadgeCheck,
@@ -70,6 +70,10 @@ import {
   type StandingRouteState,
   type StandingRouteUsage,
 } from "@/data/standing-routes";
+import {
+  filterProjectionCommands,
+  stepCommandIndex,
+} from "@/lib/command-palette";
 import { cn } from "@/lib/utils";
 import {
   qualifiedBooksTile,
@@ -13975,7 +13979,33 @@ function CommandPalette({
   onClose: () => void;
   onNavigate: (view: View) => void;
 }) {
+  const [query, setQuery] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const resultsRef = useRef<HTMLDivElement>(null);
+  const matches = filterProjectionCommands(navigation, query);
+
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setSelectedIndex(0);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    resultsRef.current
+      ?.querySelector<HTMLElement>("[aria-selected='true']")
+      ?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex, query]);
+
   if (!open) return null;
+
+  function activate(index: number): void {
+    const item = matches[index];
+    if (item === undefined) return;
+    onNavigate(item.id);
+    onClose();
+  }
+
   return (
     <div className="command-layer" role="dialog" aria-modal="true">
       <button
@@ -13989,27 +14019,66 @@ function CommandPalette({
           <Input
             autoFocus
             aria-label="Search commands"
+            aria-controls="command-palette-results"
+            aria-activedescendant={
+              matches[selectedIndex] === undefined
+                ? undefined
+                : `command-${matches[selectedIndex].id}`
+            }
             placeholder="Jump to a projection…"
+            value={query}
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setSelectedIndex(0);
+            }}
+            onKeyDown={(event) => {
+              if (event.key === "ArrowDown") {
+                event.preventDefault();
+                setSelectedIndex((index) => stepCommandIndex(matches.length, index, 1));
+              } else if (event.key === "ArrowUp") {
+                event.preventDefault();
+                setSelectedIndex((index) => stepCommandIndex(matches.length, index, -1));
+              } else if (event.key === "Enter") {
+                event.preventDefault();
+                activate(selectedIndex);
+              }
+            }}
           />
           <kbd>ESC</kbd>
         </div>
         <span className="command-group-label">Available projections</span>
-        {navigation.map((item) => {
-          const Icon = item.icon;
-          return (
-            <button
-              key={item.id}
-              onClick={() => {
-                onNavigate(item.id);
-                onClose();
-              }}
-            >
-              <Icon size={16} />
-              <span>{item.label}</span>
-              <small>Open</small>
-            </button>
-          );
-        })}
+        <div
+          ref={resultsRef}
+          id="command-palette-results"
+          className="command-results"
+          role="listbox"
+          aria-label="Available projections"
+        >
+          {matches.length === 0 ? (
+            <p className="command-empty" role="status">
+              No projections match that query.
+            </p>
+          ) : (
+            matches.map((item, index) => {
+              const Icon = item.icon;
+              return (
+                <button
+                  key={item.id}
+                  id={`command-${item.id}`}
+                  role="option"
+                  aria-selected={index === selectedIndex}
+                  className={index === selectedIndex ? "is-active" : undefined}
+                  onMouseEnter={() => setSelectedIndex(index)}
+                  onClick={() => activate(index)}
+                >
+                  <Icon size={16} />
+                  <span>{item.label}</span>
+                  <small>Open</small>
+                </button>
+              );
+            })
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -82,6 +82,7 @@ import {
   VENUE_SESSION_PICKER_HEADING,
 } from "@/lib/book-desk-copy";
 import { marketsWorkspaceCopy } from "@/lib/markets-workspace-copy";
+import { searchIssueRunNow } from "@/lib/search-issue-run-now";
 import {
   parseWorkspaceRoute,
   serializeWorkspaceRoute,
@@ -7100,6 +7101,9 @@ function MarketArchaeologistView() {
   const discoveryCapability = discoveryExecution.data?.capability;
   const discoveryRuntime = discoveryExecution.data?.runtime;
   const discoveryModel = discoveryExecution.data?.model;
+  const searchIssueRun = searchIssueRunNow({
+    dispatchEligibility: discoveryCapability?.dispatchEligibility ?? null,
+  });
   const currentLensRecords = scheduler.records.filter(
     (record) => record.lease.snapshotIdentity === corpus.snapshotIdentity,
   );
@@ -7798,7 +7802,8 @@ function MarketArchaeologistView() {
                         variant="outline"
                         disabled={
                           corpus.listingCount === 0 || issueAction !== null ||
-                          (issue.supersededByIssueId !== undefined && issue.supersededByIssueId !== null)
+                          (issue.supersededByIssueId !== undefined && issue.supersededByIssueId !== null) ||
+                          !searchIssueRun.dispatchEligible
                         }
                         onClick={() => void runIssue(issue.issueId)}
                       >
@@ -7894,7 +7899,7 @@ function MarketArchaeologistView() {
           </form>
           {!issueScheduler.enabled && (
             <p className="issue-scheduler-hint">
-              Automatic dispatch is installed but intentionally explicit. Set <code>PMH_SEARCH_ISSUE_TICK_MS</code> to 1000–60000 and restart the control plane; manual runs work now.
+              {searchIssueRun.schedulerHint}
             </p>
           )}
           {issueDiagnostic !== null && (

--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -5964,7 +5964,6 @@ function Overview({
   const catalogObservation = studioProjection.ai.catalogObservation;
   const discoveryExecution = useDiscoveryExecutionCapability();
   const exploreNext = systemExploreNextAction({
-    workers: studioProjection.ai.workers,
     dispatchEligibility:
       discoveryExecution.data?.capability.dispatchEligibility ?? null,
   });

--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -77,6 +77,7 @@ import {
   workspaceReadModel,
   type WorkspaceView,
 } from "@/lib/workspace-route";
+import { verifiedClaimsPipelineState } from "@/lib/evidence-pipeline-stage";
 
 type View = WorkspaceView;
 type Opportunity = StudioProjection["opportunities"][number];
@@ -13502,7 +13503,7 @@ function EvidenceView({
       label: "Verified claims",
       value: ruleEvidenceClaims.passedCount,
       detail: `${ruleEvidenceClaims.pendingCount + ruleEvidenceClaims.activeCount} in Agent loop · ${ruleEvidenceClaims.interruptedLeaseCount} interrupted`,
-      state: ruleEvidenceClaims.passedCount > 0 ? "INTERPRETED" : "RUNNING",
+      state: verifiedClaimsPipelineState(ruleEvidenceClaims),
     },
     {
       step: "05",

--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -78,6 +78,7 @@ import {
   type WorkspaceView,
 } from "@/lib/workspace-route";
 import { verifiedClaimsPipelineState } from "@/lib/evidence-pipeline-stage";
+import { agentTaskRunTile } from "@/lib/agent-task-run-tile";
 
 type View = WorkspaceView;
 type Opportunity = StudioProjection["opportunities"][number];
@@ -4620,7 +4621,7 @@ function AgentOperationsView() {
       <div className="metric-grid agent-metrics">
         <Metric label="Runtimes" value={`${consoleData.summary.runtimeDefinitionCount}`} detail="Pi · Codex · in-process" />
         <Metric label="Execution profiles" value={`${consoleData.summary.executionProfileCount}`} detail="immutable runtime/model compositions" />
-        <Metric label="Tasks / runs" value={`${consoleData.summary.taskCount} / ${consoleData.summary.runCount}`} detail={`${runnableTaskCount} current · ${supersededTaskCount} superseded in view`} />
+        <Metric {...agentTaskRunTile({ taskCount: consoleData.summary.taskCount, runCount: consoleData.summary.runCount, runnableCount: runnableTaskCount })} />
         <Metric label="Known tokens" value={formatTokenCount((BigInt(consoleData.usage.inputTokens) + BigInt(consoleData.usage.outputTokens)).toString())} detail={`${consoleData.usage.incompleteTokenInvocationCount} invocations incomplete`} />
       </div>
 

--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -72,6 +72,11 @@ import {
 } from "@/data/standing-routes";
 import { cn } from "@/lib/utils";
 import {
+  qualifiedBooksTile,
+  selectedVenueSessionLabel,
+  VENUE_SESSION_PICKER_HEADING,
+} from "@/lib/book-desk-copy";
+import {
   parseWorkspaceRoute,
   serializeWorkspaceRoute,
   workspaceReadModel,
@@ -12886,11 +12891,7 @@ function BookDeskView() {
       </div>
 
       <div className="book-summary-grid">
-        <Metric
-          label="Qualified books"
-          value={`${studioProjection.bookDesk.books.length}`}
-          detail="three public transports"
-        />
+        <Metric {...qualifiedBooksTile(studioProjection.bookDesk.books)} />
         <Metric
           label="Replay generation"
           value={`${studioProjection.bookDesk.replayCount}`}
@@ -12906,31 +12907,35 @@ function BookDeskView() {
       <div className="book-desk-layout">
         <div className="book-session-list">
           <div className="book-list-heading">
-            <span>Venue sessions</span>
+            <span>{VENUE_SESSION_PICKER_HEADING}</span>
             <Badge variant="verified">
               <Radio size={10} /> SSE linked
             </Badge>
           </div>
-          {studioProjection.bookDesk.books.map((book) => (
-            <button
-              className={cn(
-                "book-session",
-                selectedBook?.bookId === book.bookId && "is-selected",
-              )}
-              key={book.bookId}
-              onClick={() => setSelectedBookId(book.bookId)}
-            >
-              <span className="book-session-status" />
-              <div>
-                <strong>{book.venueName}</strong>
-                <span>{book.instrumentId}</span>
-              </div>
-              <Badge variant="muted">{book.lifecycle}</Badge>
-              <small>
-                {book.bidLevelCount} × {book.askLevelCount} levels
-              </small>
-            </button>
-          ))}
+          {studioProjection.bookDesk.books.map((book) => {
+            const selected = selectedBook?.bookId === book.bookId;
+            const showingLabel = selectedVenueSessionLabel(selected);
+            return (
+              <button
+                className={cn("book-session", selected && "is-selected")}
+                key={book.bookId}
+                onClick={() => setSelectedBookId(book.bookId)}
+              >
+                <span className="book-session-status" />
+                <div>
+                  <strong>{book.venueName}</strong>
+                  <span>{book.instrumentId}</span>
+                  {showingLabel !== undefined && (
+                    <b className="book-session-showing">{showingLabel}</b>
+                  )}
+                </div>
+                <Badge variant="muted">{book.lifecycle}</Badge>
+                <small>
+                  {book.bidLevelCount} × {book.askLevelCount} levels
+                </small>
+              </button>
+            );
+          })}
         </div>
 
         {selectedBook && (

--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -75,6 +75,7 @@ import {
   stepCommandIndex,
 } from "@/lib/command-palette";
 import { cn } from "@/lib/utils";
+import { systemExploreNextAction } from "@/lib/system-explore-next";
 import {
   qualifiedBooksTile,
   selectedVenueSessionLabel,
@@ -5961,6 +5962,12 @@ function Overview({
 }) {
   const studioProjection = useStudioProjection();
   const catalogObservation = studioProjection.ai.catalogObservation;
+  const discoveryExecution = useDiscoveryExecutionCapability();
+  const exploreNext = systemExploreNextAction({
+    workers: studioProjection.ai.workers,
+    dispatchEligibility:
+      discoveryExecution.data?.capability.dispatchEligibility ?? null,
+  });
   const [scoutStatus, setScoutStatus] = useState<
     "IDLE" | "RUNNING" | "DONE" | "RESTORED" | "FAILED"
   >("IDLE");
@@ -6078,22 +6085,43 @@ function Overview({
               <p>The scheduler chooses a fresh trailhead; the Agent forms claims after inspection.</p>
             </div>
           </div>
-          <Button
-            disabled={scoutStatus === "RUNNING"}
-            onClick={() => void runScout()}
-          >
-            <Sparkles size={11} />
-            {scoutStatus === "RUNNING"
-              ? "Scouting…"
-              : scoutStatus === "DONE"
-                ? "Scan complete"
-                : scoutStatus === "RESTORED"
-                  ? "Already scanned"
-                : scoutStatus === "FAILED"
-                  ? "Retry scout"
-                  : "Explore next"}
-          </Button>
+          {exploreNext.kind === "SCOUT" ? (
+            <Button
+              disabled={scoutStatus === "RUNNING"}
+              onClick={() => void runScout()}
+            >
+              <Sparkles size={11} />
+              {scoutStatus === "RUNNING"
+                ? "Scouting…"
+                : scoutStatus === "DONE"
+                  ? "Scan complete"
+                  : scoutStatus === "RESTORED"
+                    ? "Already scanned"
+                    : scoutStatus === "FAILED"
+                      ? "Retry scout"
+                      : exploreNext.label}
+            </Button>
+          ) : (
+            <Button
+              variant="outline"
+              onClick={() => {
+                window.location.assign(exploreNext.href);
+              }}
+            >
+              <Bot size={11} />
+              Open Agent operations
+            </Button>
+          )}
         </div>
+        {exploreNext.kind === "NEEDS_SETUP" && (
+          <div className="inline-alert" role="status">
+            <CircleOff size={14} />
+            <span>
+              Scout needs the existing Codex or heuristic session in{" "}
+              <a href={exploreNext.href}>Agent operations</a>.
+            </span>
+          </div>
+        )}
 
         <div className="ai-runtime-panel">
           <div className="ai-runtime-panel-heading">

--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -81,6 +81,7 @@ import {
   selectedVenueSessionLabel,
   VENUE_SESSION_PICKER_HEADING,
 } from "@/lib/book-desk-copy";
+import { marketsWorkspaceCopy } from "@/lib/markets-workspace-copy";
 import {
   parseWorkspaceRoute,
   serializeWorkspaceRoute,
@@ -3904,15 +3905,18 @@ async function requestCandidateWatchRefresh(): Promise<"READY" | "DEGRADED"> {
 function SidebarStatus() {
   const studioProjection = useStudioProjection();
   const observation = studioProjection.ai.catalogObservation;
+  const copy = marketsWorkspaceCopy({
+    healthySourceCount: observation.healthySourceCount,
+    sourceCount: observation.sourceCount,
+    listingCount: observation.listingCount,
+    venueAdapterCount: studioProjection.venues.length,
+  });
   return (
     <div className="sidebar-status">
       <span className="sidebar-status-dot" />
       <div>
         <strong>System ready</strong>
-        <span>
-          {observation.healthySourceCount}/{observation.sourceCount} sources ·{" "}
-          {observation.listingCount} markets
-        </span>
+        <span>{copy.sidebarCatalogLine}</span>
       </div>
     </div>
   );
@@ -12790,15 +12794,19 @@ function ResearchCaseDeskView() {
 
 function VenueMatrix() {
   const studioProjection = useStudioProjection();
+  const observation = studioProjection.ai.catalogObservation;
+  const copy = marketsWorkspaceCopy({
+    healthySourceCount: observation.healthySourceCount,
+    sourceCount: observation.sourceCount,
+    listingCount: observation.listingCount,
+    venueAdapterCount: studioProjection.venues.length,
+  });
   return (
     <section className="page-section">
       <div className="page-heading">
         <span className="eyebrow">Protocol reality</span>
-        <h1>Venue capability matrix</h1>
-        <p>
-          Each adapter owns its precision, authentication boundary, mechanism,
-          and qualification evidence.
-        </p>
+        <h1>{copy.pageTitle}</h1>
+        <p>{copy.pageDescription}</p>
       </div>
       <div className="venue-grid">
         {studioProjection.venues.map((venue) => (

--- a/apps/studio/src/index.css
+++ b/apps/studio/src/index.css
@@ -4162,6 +4162,13 @@ main {
   font-size: 13px;
 }
 
+.book-session-showing {
+  color: var(--primary);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
 .book-session > div span,
 .book-session small {
   overflow: hidden;

--- a/apps/studio/src/index.css
+++ b/apps/studio/src/index.css
@@ -4877,7 +4877,11 @@ footer span:first-child {
 
 .command-palette {
   position: relative;
+  display: flex;
+  flex-direction: column;
   width: min(540px, calc(100vw - 28px));
+  /* Leave the last projection rows reachable instead of clipping them. */
+  max-height: calc(100vh - min(18vh, 150px) - 24px);
   overflow: hidden;
   border: 1px solid #2b3437;
   border-radius: 13px;
@@ -4927,7 +4931,20 @@ footer span:first-child {
   text-transform: uppercase;
 }
 
-.command-palette > button:not(.command-scrim) {
+.command-results {
+  min-height: 0;
+  overflow-y: auto;
+  padding-bottom: 6px;
+}
+
+.command-empty {
+  color: #7b8580;
+  font-size: 13px;
+  margin: 0;
+  padding: 18px 15px 22px;
+}
+
+.command-results > button {
   display: grid;
   width: calc(100% - 12px);
   height: 43px;
@@ -4944,12 +4961,13 @@ footer span:first-child {
   text-align: left;
 }
 
-.command-palette > button:not(.command-scrim):hover {
+.command-results > button.is-active,
+.command-results > button:hover {
   background: rgba(126, 240, 193, 0.07);
   color: var(--primary);
 }
 
-.command-palette button small {
+.command-results button small {
   color: #56605b;
   font-family: inherit;
   font-size: 12px;

--- a/apps/studio/src/lib/agent-task-run-tile.test.ts
+++ b/apps/studio/src/lib/agent-task-run-tile.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { agentTaskRunTile } from "./agent-task-run-tile.js";
+
+describe("agentTaskRunTile", () => {
+  it("puts retained tasks in the headline and names the other two counts", () => {
+    expect(agentTaskRunTile({
+      taskCount: 150,
+      runCount: 0,
+      runnableCount: 128,
+    })).toEqual({
+      label: "Tasks",
+      value: "150",
+      detail: "128 runnable · 0 runs",
+    });
+  });
+
+  it("does not put a slash pair in the value so idle desks do not look stalled", () => {
+    const tile = agentTaskRunTile({
+      taskCount: 150,
+      runCount: 0,
+      runnableCount: 128,
+    });
+    expect(tile.value.includes("/")).toBe(false);
+  });
+});

--- a/apps/studio/src/lib/agent-task-run-tile.ts
+++ b/apps/studio/src/lib/agent-task-run-tile.ts
@@ -1,0 +1,19 @@
+export type AgentTaskRunCounts = Readonly<{
+  taskCount: number;
+  runCount: number;
+  runnableCount: number;
+}>;
+
+export type AgentTaskRunTile = Readonly<{
+  label: string;
+  value: string;
+  detail: string;
+}>;
+
+export function agentTaskRunTile(counts: AgentTaskRunCounts): AgentTaskRunTile {
+  return {
+    label: "Tasks",
+    value: String(counts.taskCount),
+    detail: `${counts.runnableCount} runnable · ${counts.runCount} runs`,
+  };
+}

--- a/apps/studio/src/lib/book-desk-copy.test.ts
+++ b/apps/studio/src/lib/book-desk-copy.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  qualifiedBooksTile,
+  selectedVenueSessionLabel,
+  VENUE_SESSION_PICKER_HEADING,
+} from "./book-desk-copy.js";
+
+const fourVenueSessions = [
+  { bookId: "gemini-predictions:yes" },
+  { bookId: "limitless:yes" },
+  { bookId: "polymarket-global:yes" },
+  { bookId: "polymarket-us:yes" },
+] as const;
+
+describe("qualifiedBooksTile", () => {
+  it("names the qualified-books tile from the sessions on screen", () => {
+    expect(qualifiedBooksTile(fourVenueSessions)).toEqual({
+      label: "Qualified books",
+      value: "4",
+      detail: "4 venue sessions",
+    });
+  });
+
+  it("does not hardcode a three-transport count", () => {
+    expect(qualifiedBooksTile([{ bookId: "gemini-predictions:yes" }])).toEqual({
+      label: "Qualified books",
+      value: "1",
+      detail: "1 venue session",
+    });
+    expect(qualifiedBooksTile([])).toEqual({
+      label: "Qualified books",
+      value: "0",
+      detail: "0 venue sessions",
+    });
+  });
+});
+
+describe("venue session picker copy", () => {
+  it("labels the list as a selector and the selected row as Showing", () => {
+    expect(VENUE_SESSION_PICKER_HEADING).toBe("Select a venue session");
+    expect(selectedVenueSessionLabel(true)).toBe("Showing");
+    expect(selectedVenueSessionLabel(false)).toBeUndefined();
+  });
+});

--- a/apps/studio/src/lib/book-desk-copy.ts
+++ b/apps/studio/src/lib/book-desk-copy.ts
@@ -1,0 +1,23 @@
+export type QualifiedBooksTile = Readonly<{
+  label: string;
+  value: string;
+  detail: string;
+}>;
+
+export const VENUE_SESSION_PICKER_HEADING = "Select a venue session";
+export const SELECTED_VENUE_SESSION_LABEL = "Showing";
+
+export function qualifiedBooksTile(
+  books: readonly Readonly<{ bookId: string }>[],
+): QualifiedBooksTile {
+  const count = books.length;
+  return {
+    label: "Qualified books",
+    value: String(count),
+    detail: count === 1 ? "1 venue session" : `${count} venue sessions`,
+  };
+}
+
+export function selectedVenueSessionLabel(selected: boolean): string | undefined {
+  return selected ? SELECTED_VENUE_SESSION_LABEL : undefined;
+}

--- a/apps/studio/src/lib/command-palette.test.ts
+++ b/apps/studio/src/lib/command-palette.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterProjectionCommands,
+  stepCommandIndex,
+} from "./command-palette.js";
+
+const projections = [
+  { id: "archaeologist", label: "Discover" },
+  { id: "scouts", label: "Findings" },
+  { id: "budgets", label: "Failure budgets" },
+  { id: "lifecycle", label: "Review queue" },
+  { id: "preflight", label: "Preflight" },
+  { id: "venues", label: "Markets" },
+  { id: "evidence", label: "Evidence" },
+  { id: "overview", label: "System overview" },
+  { id: "agents", label: "Agent operations" },
+  { id: "radar", label: "Similarity radar" },
+  { id: "cases", label: "Research cases" },
+  { id: "books", label: "Order books" },
+] as const;
+
+describe("command palette projection filter", () => {
+  it("keeps every existing projection when the query is empty", () => {
+    expect(filterProjectionCommands(projections, "")).toEqual(projections);
+    expect(filterProjectionCommands(projections, "   ")).toEqual(projections);
+  });
+
+  it("filters visible projection labels as the operator types", () => {
+    expect(filterProjectionCommands(projections, "book").map((item) => item.id))
+      .toEqual(["books"]);
+    expect(filterProjectionCommands(projections, "REVIEW").map((item) => item.label))
+      .toEqual(["Review queue"]);
+    expect(filterProjectionCommands(projections, "radar")).toEqual([
+      projections.find((item) => item.id === "radar"),
+    ]);
+  });
+
+  it("returns no destinations when nothing matches", () => {
+    expect(filterProjectionCommands(projections, "dispatch spend")).toEqual([]);
+    expect(filterProjectionCommands(projections, "zzz")).toEqual([]);
+  });
+
+  it("does not invent commands from internal view ids", () => {
+    expect(filterProjectionCommands(projections, "scouts")).toEqual([]);
+    expect(filterProjectionCommands(projections, "lifecycle")).toEqual([]);
+  });
+
+  it("wraps keyboard highlight across the filtered rows", () => {
+    expect(stepCommandIndex(12, 11, 1)).toBe(0);
+    expect(stepCommandIndex(12, 0, -1)).toBe(11);
+    expect(stepCommandIndex(1, 0, 1)).toBe(0);
+    expect(stepCommandIndex(0, 3, 1)).toBe(0);
+  });
+});

--- a/apps/studio/src/lib/command-palette.ts
+++ b/apps/studio/src/lib/command-palette.ts
@@ -1,0 +1,22 @@
+export type ProjectionCommand = Readonly<{
+  id: string;
+  label: string;
+}>;
+
+export function filterProjectionCommands<T extends ProjectionCommand>(
+  items: readonly T[],
+  query: string,
+): readonly T[] {
+  const needle = query.trim().toLowerCase();
+  if (needle.length === 0) return items;
+  return items.filter((item) => item.label.toLowerCase().includes(needle));
+}
+
+export function stepCommandIndex(
+  count: number,
+  current: number,
+  delta: 1 | -1,
+): number {
+  if (count <= 0) return 0;
+  return (current + delta + count) % count;
+}

--- a/apps/studio/src/lib/evidence-pipeline-stage.test.ts
+++ b/apps/studio/src/lib/evidence-pipeline-stage.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { verifiedClaimsPipelineState } from "./evidence-pipeline-stage.js";
+
+describe("verifiedClaimsPipelineState", () => {
+  it("is interpreted after a passed claim", () => {
+    expect(verifiedClaimsPipelineState({
+      passedCount: 1,
+      pendingCount: 0,
+      activeCount: 0,
+    })).toBe("INTERPRETED");
+  });
+
+  it("is running only while claims are in the Agent loop", () => {
+    expect(verifiedClaimsPipelineState({
+      passedCount: 0,
+      pendingCount: 1,
+      activeCount: 0,
+    })).toBe("RUNNING");
+    expect(verifiedClaimsPipelineState({
+      passedCount: 0,
+      pendingCount: 0,
+      activeCount: 2,
+    })).toBe("RUNNING");
+  });
+
+  it("is waiting when the lane is idle so PAUSED desks do not show RUNNING", () => {
+    expect(verifiedClaimsPipelineState({
+      passedCount: 0,
+      pendingCount: 0,
+      activeCount: 0,
+    })).toBe("WAITING");
+  });
+});

--- a/apps/studio/src/lib/evidence-pipeline-stage.ts
+++ b/apps/studio/src/lib/evidence-pipeline-stage.ts
@@ -1,0 +1,13 @@
+export type VerifiedClaimsCounts = Readonly<{
+  passedCount: number;
+  pendingCount: number;
+  activeCount: number;
+}>;
+
+export function verifiedClaimsPipelineState(
+  claims: VerifiedClaimsCounts,
+): "INTERPRETED" | "RUNNING" | "WAITING" {
+  if (claims.passedCount > 0) return "INTERPRETED";
+  if (claims.pendingCount + claims.activeCount > 0) return "RUNNING";
+  return "WAITING";
+}

--- a/apps/studio/src/lib/markets-workspace-copy.test.ts
+++ b/apps/studio/src/lib/markets-workspace-copy.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { marketsWorkspaceCopy } from "./markets-workspace-copy.js";
+
+const observed = {
+  healthySourceCount: 5,
+  sourceCount: 7,
+  listingCount: 580,
+  venueAdapterCount: 7,
+} as const;
+
+describe("marketsWorkspaceCopy", () => {
+  it("does not call catalog listingCount markets next to the Markets venue matrix", () => {
+    const copy = marketsWorkspaceCopy(observed);
+    expect(copy.sidebarCatalogLine).toBe("5/7 sources · 580 listings");
+    expect(copy.sidebarCatalogLine.toLowerCase()).not.toContain("market");
+    expect(copy.pageTitle).toBe("Venue capability matrix");
+    expect(copy.pageDescription).toContain("7 venue adapters");
+    expect(copy.pageDescription).toContain("580 listings");
+    expect(copy.pageDescription).toContain("not a listing browser");
+  });
+
+  it("uses the same listing count on the Markets page as in the sidebar", () => {
+    const copy = marketsWorkspaceCopy({
+      ...observed,
+      listingCount: 1,
+      venueAdapterCount: 1,
+    });
+    expect(copy.sidebarCatalogLine).toBe("5/7 sources · 1 listing");
+    expect(copy.pageDescription).toContain("1 venue adapter");
+    expect(copy.pageDescription).toContain("1 listing");
+    expect(copy.pageDescription).not.toMatch(/market/i);
+  });
+});

--- a/apps/studio/src/lib/markets-workspace-copy.ts
+++ b/apps/studio/src/lib/markets-workspace-copy.ts
@@ -1,0 +1,35 @@
+export type MarketsWorkspaceCounts = Readonly<{
+  healthySourceCount: number;
+  sourceCount: number;
+  listingCount: number;
+  venueAdapterCount: number;
+}>;
+
+export type MarketsWorkspaceCopy = Readonly<{
+  sidebarCatalogLine: string;
+  pageTitle: string;
+  pageDescription: string;
+}>;
+
+export const MARKETS_PAGE_TITLE = "Venue capability matrix";
+
+export function marketsWorkspaceCopy(
+  counts: MarketsWorkspaceCounts,
+): MarketsWorkspaceCopy {
+  const listings = countPhrase(counts.listingCount, "listing", "listings");
+  const adapters = countPhrase(
+    counts.venueAdapterCount,
+    "venue adapter",
+    "venue adapters",
+  );
+  return {
+    sidebarCatalogLine: `${counts.healthySourceCount}/${counts.sourceCount} sources · ${listings}`,
+    pageTitle: MARKETS_PAGE_TITLE,
+    pageDescription:
+      `These are ${adapters}, not a listing browser. The catalog currently holds ${listings}. Each adapter owns its precision, authentication boundary, mechanism, and qualification evidence.`,
+  };
+}
+
+function countPhrase(count: number, singular: string, plural: string): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}

--- a/apps/studio/src/lib/search-issue-run-now.test.ts
+++ b/apps/studio/src/lib/search-issue-run-now.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { searchIssueRunNow } from "./search-issue-run-now.js";
+
+describe("search issue Run now", () => {
+  it("allows Run now only when discovery can dispatch", () => {
+    expect(searchIssueRunNow({
+      dispatchEligibility: "ELIGIBLE",
+    })).toEqual({
+      dispatchEligible: true,
+      schedulerHint:
+        "Automatic dispatch is installed but intentionally explicit. Set PMH_SEARCH_ISSUE_TICK_MS to 1000–60000 and restart the control plane; manual runs work now.",
+    });
+  });
+
+  it("does not claim manual runs work when dispatch is blocked or unknown", () => {
+    for (const dispatchEligibility of ["BLOCKED", null] as const) {
+      const result = searchIssueRunNow({ dispatchEligibility });
+      expect(result.dispatchEligible).toBe(false);
+      expect(result.schedulerHint).toBe(
+        "Automatic dispatch is installed but intentionally explicit. Manual Run now stays blocked until discovery can dispatch.",
+      );
+      expect(result.schedulerHint.toLowerCase()).not.toContain("manual runs work now");
+      expect(result.schedulerHint).not.toContain("PMH_SEARCH_ISSUE_TICK_MS");
+    }
+  });
+});

--- a/apps/studio/src/lib/search-issue-run-now.ts
+++ b/apps/studio/src/lib/search-issue-run-now.ts
@@ -1,0 +1,18 @@
+export type SearchIssueRunNow = Readonly<{
+  dispatchEligible: boolean;
+  schedulerHint: string;
+}>;
+
+export function searchIssueRunNow(input: {
+  readonly dispatchEligibility: "ELIGIBLE" | "BLOCKED" | null;
+}): SearchIssueRunNow {
+  // POST /api/v1/search-issues/:id/runs spends the discovery route, same as
+  // the hero scan. Pause/resume is local via requestSearchIssueEnabled.
+  const dispatchEligible = input.dispatchEligibility === "ELIGIBLE";
+  return Object.freeze({
+    dispatchEligible,
+    schedulerHint: dispatchEligible
+      ? "Automatic dispatch is installed but intentionally explicit. Set PMH_SEARCH_ISSUE_TICK_MS to 1000–60000 and restart the control plane; manual runs work now."
+      : "Automatic dispatch is installed but intentionally explicit. Manual Run now stays blocked until discovery can dispatch.",
+  });
+}

--- a/apps/studio/src/lib/system-explore-next.test.ts
+++ b/apps/studio/src/lib/system-explore-next.test.ts
@@ -3,66 +3,25 @@ import { describe, expect, it } from "vitest";
 import { systemExploreNextAction } from "./system-explore-next.js";
 import { serializeWorkspaceRoute } from "./workspace-route.js";
 
-const heuristicReady = Object.freeze({
-  kind: "HEURISTIC" as const,
-  status: "READY" as const,
-});
-const modelNeedsKey = Object.freeze({
-  kind: "MODEL" as const,
-  status: "NEEDS_KEY" as const,
-});
-const modelReady = Object.freeze({
-  kind: "MODEL" as const,
-  status: "READY" as const,
-});
-
 describe("system overview Explore next", () => {
-  it("keeps Explore next when the routed discovery profile can dispatch", () => {
+  it("keeps Explore next only when discovery can dispatch", () => {
     expect(systemExploreNextAction({
-      workers: [heuristicReady, modelReady],
       dispatchEligibility: "ELIGIBLE",
     })).toEqual({ kind: "SCOUT", label: "Explore next" });
   });
 
-  it("labels the remaining heuristic-only path when the model lane needs a key", () => {
+  it("does not keep a clickable scout when dispatch is blocked or unknown", () => {
     expect(systemExploreNextAction({
-      workers: [heuristicReady, modelNeedsKey],
-      dispatchEligibility: "BLOCKED",
-    })).toEqual({ kind: "SCOUT", label: "Explore next · heuristic" });
-    expect(systemExploreNextAction({
-      workers: [heuristicReady, modelNeedsKey],
-      dispatchEligibility: null,
-    })).toEqual({ kind: "SCOUT", label: "Explore next · heuristic" });
-  });
-
-  it("does not keep a green Explore next when the model looks ready but cannot dispatch", () => {
-    expect(systemExploreNextAction({
-      workers: [heuristicReady, modelReady],
       dispatchEligibility: "BLOCKED",
     })).toEqual({
       kind: "NEEDS_SETUP",
       href: serializeWorkspaceRoute("agents"),
     });
     expect(systemExploreNextAction({
-      workers: [modelReady],
       dispatchEligibility: null,
     })).toEqual({
       kind: "NEEDS_SETUP",
       href: "?view=agents",
     });
-  });
-
-  it("points at Agent operations when no honest scout path exists", () => {
-    expect(systemExploreNextAction({
-      workers: [modelNeedsKey],
-      dispatchEligibility: "BLOCKED",
-    })).toEqual({
-      kind: "NEEDS_SETUP",
-      href: "?view=agents",
-    });
-    expect(systemExploreNextAction({
-      workers: [],
-      dispatchEligibility: null,
-    }).kind).toBe("NEEDS_SETUP");
   });
 });

--- a/apps/studio/src/lib/system-explore-next.test.ts
+++ b/apps/studio/src/lib/system-explore-next.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { systemExploreNextAction } from "./system-explore-next.js";
+import { serializeWorkspaceRoute } from "./workspace-route.js";
+
+const heuristicReady = Object.freeze({
+  kind: "HEURISTIC" as const,
+  status: "READY" as const,
+});
+const modelNeedsKey = Object.freeze({
+  kind: "MODEL" as const,
+  status: "NEEDS_KEY" as const,
+});
+const modelReady = Object.freeze({
+  kind: "MODEL" as const,
+  status: "READY" as const,
+});
+
+describe("system overview Explore next", () => {
+  it("keeps Explore next when the routed discovery profile can dispatch", () => {
+    expect(systemExploreNextAction({
+      workers: [heuristicReady, modelReady],
+      dispatchEligibility: "ELIGIBLE",
+    })).toEqual({ kind: "SCOUT", label: "Explore next" });
+  });
+
+  it("labels the remaining heuristic-only path when the model lane needs a key", () => {
+    expect(systemExploreNextAction({
+      workers: [heuristicReady, modelNeedsKey],
+      dispatchEligibility: "BLOCKED",
+    })).toEqual({ kind: "SCOUT", label: "Explore next · heuristic" });
+    expect(systemExploreNextAction({
+      workers: [heuristicReady, modelNeedsKey],
+      dispatchEligibility: null,
+    })).toEqual({ kind: "SCOUT", label: "Explore next · heuristic" });
+  });
+
+  it("does not keep a green Explore next when the model looks ready but cannot dispatch", () => {
+    expect(systemExploreNextAction({
+      workers: [heuristicReady, modelReady],
+      dispatchEligibility: "BLOCKED",
+    })).toEqual({
+      kind: "NEEDS_SETUP",
+      href: serializeWorkspaceRoute("agents"),
+    });
+    expect(systemExploreNextAction({
+      workers: [modelReady],
+      dispatchEligibility: null,
+    })).toEqual({
+      kind: "NEEDS_SETUP",
+      href: "?view=agents",
+    });
+  });
+
+  it("points at Agent operations when no honest scout path exists", () => {
+    expect(systemExploreNextAction({
+      workers: [modelNeedsKey],
+      dispatchEligibility: "BLOCKED",
+    })).toEqual({
+      kind: "NEEDS_SETUP",
+      href: "?view=agents",
+    });
+    expect(systemExploreNextAction({
+      workers: [],
+      dispatchEligibility: null,
+    }).kind).toBe("NEEDS_SETUP");
+  });
+});

--- a/apps/studio/src/lib/system-explore-next.ts
+++ b/apps/studio/src/lib/system-explore-next.ts
@@ -1,0 +1,48 @@
+import { serializeWorkspaceRoute } from "./workspace-route.js";
+
+export type SystemExploreWorker = Readonly<{
+  kind: "HEURISTIC" | "MODEL";
+  status: "READY" | "NEEDS_KEY" | "NEEDS_PROVIDER";
+}>;
+
+export type SystemExploreNextAction = Readonly<
+  | { kind: "SCOUT"; label: "Explore next" | "Explore next · heuristic" }
+  | { kind: "NEEDS_SETUP"; href: string }
+>;
+
+export function systemExploreNextAction(input: {
+  readonly workers: readonly SystemExploreWorker[];
+  readonly dispatchEligibility: "ELIGIBLE" | "BLOCKED" | null;
+}): SystemExploreNextAction {
+  const heuristicReady = input.workers.some(
+    (worker) => worker.kind === "HEURISTIC" && worker.status === "READY",
+  );
+  const modelReady = input.workers.some(
+    (worker) => worker.kind === "MODEL" && worker.status === "READY",
+  );
+
+  if (input.dispatchEligibility === "ELIGIBLE") {
+    return Object.freeze({ kind: "SCOUT", label: "Explore next" as const });
+  }
+
+  // A model worker can appear READY while Codex dispatch is still blocked.
+  // The lease refuses that path, so do not keep a green Explore next.
+  if (modelReady) {
+    return Object.freeze({
+      kind: "NEEDS_SETUP",
+      href: serializeWorkspaceRoute("agents"),
+    });
+  }
+
+  if (heuristicReady) {
+    return Object.freeze({
+      kind: "SCOUT",
+      label: "Explore next · heuristic" as const,
+    });
+  }
+
+  return Object.freeze({
+    kind: "NEEDS_SETUP",
+    href: serializeWorkspaceRoute("agents"),
+  });
+}

--- a/apps/studio/src/lib/system-explore-next.ts
+++ b/apps/studio/src/lib/system-explore-next.ts
@@ -1,46 +1,19 @@
 import { serializeWorkspaceRoute } from "./workspace-route.js";
 
-export type SystemExploreWorker = Readonly<{
-  kind: "HEURISTIC" | "MODEL";
-  status: "READY" | "NEEDS_KEY" | "NEEDS_PROVIDER";
-}>;
-
 export type SystemExploreNextAction = Readonly<
-  | { kind: "SCOUT"; label: "Explore next" | "Explore next · heuristic" }
+  | { kind: "SCOUT"; label: "Explore next" }
   | { kind: "NEEDS_SETUP"; href: string }
 >;
 
 export function systemExploreNextAction(input: {
-  readonly workers: readonly SystemExploreWorker[];
   readonly dispatchEligibility: "ELIGIBLE" | "BLOCKED" | null;
 }): SystemExploreNextAction {
-  const heuristicReady = input.workers.some(
-    (worker) => worker.kind === "HEURISTIC" && worker.status === "READY",
-  );
-  const modelReady = input.workers.some(
-    (worker) => worker.kind === "MODEL" && worker.status === "READY",
-  );
-
+  // Search leases always requireDispatchEligible. There is no Studio path
+  // that runs heuristic-fast-1 without that gate, so a heuristic suffix
+  // would still call runScout and bounce.
   if (input.dispatchEligibility === "ELIGIBLE") {
     return Object.freeze({ kind: "SCOUT", label: "Explore next" as const });
   }
-
-  // A model worker can appear READY while Codex dispatch is still blocked.
-  // The lease refuses that path, so do not keep a green Explore next.
-  if (modelReady) {
-    return Object.freeze({
-      kind: "NEEDS_SETUP",
-      href: serializeWorkspaceRoute("agents"),
-    });
-  }
-
-  if (heuristicReady) {
-    return Object.freeze({
-      kind: "SCOUT",
-      label: "Explore next · heuristic" as const,
-    });
-  }
-
   return Object.freeze({
     kind: "NEEDS_SETUP",
     href: serializeWorkspaceRoute("agents"),

--- a/apps/studio/src/product-shell.css
+++ b/apps/studio/src/product-shell.css
@@ -3604,6 +3604,12 @@ footer {
   font-size: 13px;
 }
 
+.inline-alert a {
+  color: inherit;
+  font-weight: 650;
+  text-decoration: underline;
+}
+
 @media (max-width: 900px) {
   .agent-console-grid,
   .agent-control-form,


### PR DESCRIPTION
Topic PR. Independent of Books-as-blotter (#14), Fast search Busy (#27), Discover overdue (#33), raw gross floor (#34), and certificate-drawer clip (#35). Those stay pressed and are not in this branch.

Replaces closed #43 (that PR had an empty head owner, so the public pulls page 404'd). Same RainMona branch, same review. Do not merge.

## Why this exists

The desk kept lying about what a number or a button would do: Evidence PAUSED+RUNNING, Agents 150/0/128 in one tile, Books 4 vs three transports, ⌘K that did not search, System Explore next still green without a key, Markets sidebar calling listings "markets", Discover Run now still armed when dispatch is blocked. That is one honesty theme, not seven review threads.

This branch is those fixes from `origin/main`, including the System Explore next follow-up that dropped the fake heuristic suffix. No orders, signing, or funds. No merge.

## Supersedes

| Small PR | Issue | What it did |
| --- | --- | --- |
| #19 | #13 | Idle Evidence claims are not RUNNING |
| #21 | #20 | Agents task counts are named, not one slash tile |
| #24 | #22 | Books tile is named from the venue sessions on screen |
| #25 | #23 | Command palette filters to existing projections |
| #29 | #28 | System Explore next is not a green scout when dispatch is blocked |
| #31 | #26 | Sidebar listingCount is listings, not markets |
| #36 | #30 | Discover Run now uses the same dispatch gate as the hero scan |

Those small PRs are already closed as superseded.

## How to check

Look-only. Do not enable trading. Do not take 5173 / 4100. Do not click Run now / Explore next / triage.

1. Open Studio (idle port is fine, e.g. `http://127.0.0.1:4220/`).
2. Evidence should not show PAUSED and RUNNING at once on an idle tick.
3. Agents Tasks / runs should name retained vs runnable vs runs.
4. Books should describe the venue sessions actually on screen.
5. ⌘K should filter; System Explore next should not scout without dispatch eligibility.
6. Sidebar next to Markets should say listings. Discover Run now should be grey when the hero scan is.
7. Sidebar remains **Analysis only · no execution**.