### PR TITLE
Fix first-time Studio quick start

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -6,6 +6,17 @@ current dependency graph) is qualified on Node 22.22.1; Node 24 remains
 compatible but is no longer required. `@types/node` follows the Node 22 line so
 type checking cannot silently admit a Node 24-only API.
 
+The 2026-08-20 first-time-user audit used one retained Grok Build session
+(`01a01dc2-1618-7853-984b-ba85974960eb`) against a clean `origin/main`
+worktree. The documented install, workspace check, and test path passed, while
+an occupied control-plane port reproduced a misleading partial startup: the
+Node process failed but Vite advanced to another port and stayed live. Mainline
+now treats Studio and the control plane as one supervised command, rejects an
+occupied `127.0.0.1:4100` before starting either child, and documents the
+current empty-first-run navigation. Future audits for this topic should resume
+and compact that session, but Git state and command results—not Agent prose—are
+the acceptance evidence.
+
 The product brand is **Auto Prediction**, paired conceptually with Auto Quant.
 The rename is presentation-only for now: `pmh` CLI, package scopes, environment
 variables, and content-addressed protocol/schema identifiers remain stable

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ pnpm studio
 - Studio: Vite starts at `http://127.0.0.1:5173` and automatically advances to
   `5174`, `5175`, and later ports when a port is occupied
 
+Use the Studio URL printed by Vite. Port `4100` is exclusive: if the control
+plane cannot bind, the command stops Studio too and exits with an error instead
+of leaving a dashboard that can only report an offline backend.
+
 The default operational database is `.data/control-plane.sqlite` in WAL mode.
 It is ignored by Git. The UI remains useful without a DeepSeek key because the
 default Codex route uses the local Codex OAuth session; model availability is
@@ -116,17 +120,25 @@ smoke commands, read [Operations](docs/OPERATIONS.md).
 
 ## First use
 
-1. Open Studio and check **Readiness** for the control plane, catalog, storage,
-   Agent runtime, and credential posture.
-2. Refresh anonymous catalogs. A refresh creates a new immutable corpus; it
-   does not spend model budget or grant trading authority.
-3. Open the ontology / discovery workspace and inspect the standing campaigns.
-   Run a bounded campaign or issue against the retained corpus.
-4. Read the effect timeline, exact listing references, counterexamples, and
-   token usage. An empty or falsified run is retained research evidence.
-5. Move only a grounded multi-listing hypothesis into independent review.
-6. Treat economic hints as routing signals until fresh books, fees, depth, and
-   the exact verifier all agree.
+1. Studio opens on **Discover**. Before spending model budget, open **System
+   overview** in the **System** section and confirm the control plane, SQLite
+   store, catalog, Agent runtime, and credential posture are reported honestly.
+2. Select **Refresh catalogs** on **System overview**. A refresh creates a new
+   immutable anonymous corpus; it does not call a model or grant trading
+   authority.
+3. Open **Agent operations** and run its **Preflight** action. This checks the
+   selected runtime, credential, model, and effort without silently changing
+   provider.
+4. Return to **Discover** and start with a broad semantic neighborhood rather
+   than a preconceived claim. Create a paused campaign first if you want to
+   inspect its scope and budget before activation.
+5. Open **Findings** for retained runs and standing routes. Read the effect
+   timeline, exact listing references, counterexamples, and token usage. Empty
+   and falsified runs remain research evidence.
+6. Send only a grounded multi-listing hypothesis to **Review queue**, then open
+   the separate **Preflight** workspace for exact economic screening. Treat
+   every hint as routing-only until fresh books, fees, depth, and the
+   first-party verifier agree.
 
 The longer operator walkthrough is in [Studio](docs/STUDIO.md).
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -22,7 +22,9 @@ pnpm studio
 
 `pnpm studio` runs the Node control plane and the Vite dashboard together. The
 control plane binds `127.0.0.1:4100`. Vite starts at `127.0.0.1:5173` and
-increments the port when it is already occupied.
+increments the port when it is already occupied. Use the URL Vite prints. The
+command supervises both children: if either exits, the other is stopped too, so
+a control-plane bind failure cannot look like a successfully started Studio.
 
 Useful health checks:
 

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "fixtures:capture": "node scripts/capture-public-fixtures.mjs",
     "fixtures:capture:streams": "node scripts/capture-public-stream-fixtures.mjs",
     "pmh": "pnpm -r build && node packages/cli/dist/main.js",
-    "studio": "pnpm --parallel --filter @pmh/control-plane --filter @pmh/studio dev",
+    "studio": "node scripts/studio.mjs",
     "studio:build": "pnpm --filter @pmh/control-plane build && pnpm --filter @pmh/studio build",
-    "test": "pnpm -r test",
+    "test": "node --test scripts/studio-supervisor.test.mjs && pnpm -r test",
     "test:coverage": "pnpm -r test:coverage"
   },
   "devDependencies": {

--- a/scripts/studio-supervisor.mjs
+++ b/scripts/studio-supervisor.mjs
@@ -1,0 +1,104 @@
+import { spawn } from "node:child_process";
+import { createServer } from "node:net";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+export function assertPortAvailable({
+  host = "127.0.0.1",
+  port = 4_100,
+  createProbeServer = createServer,
+} = {}) {
+  return new Promise((resolveAvailable, rejectUnavailable) => {
+    const probe = createProbeServer();
+    probe.unref();
+    probe.once("error", (error) => {
+      if (error.code === "EADDRINUSE") {
+        rejectUnavailable(new Error(
+          `control-plane port http://${host}:${port} is already in use`,
+        ));
+        return;
+      }
+      rejectUnavailable(error);
+    });
+    probe.listen(port, host, () => {
+      probe.close((error) => {
+        if (error !== undefined) rejectUnavailable(error);
+        else resolveAvailable();
+      });
+    });
+  });
+}
+
+export function stopChild(child, signal = "SIGTERM") {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  try {
+    if (process.platform !== "win32" && child.pid !== undefined) {
+      process.kill(-child.pid, signal);
+    } else {
+      child.kill(signal);
+    }
+  } catch (error) {
+    if (error?.code !== "ESRCH") throw error;
+  }
+}
+
+export function superviseStudio(children, { stderr = process.stderr } = {}) {
+  return new Promise((resolveExit) => {
+    let settled = false;
+
+    const settle = (source, code, signal, error) => {
+      if (settled) return;
+      settled = true;
+      for (const candidate of children) {
+        if (candidate !== source) stopChild(candidate.child);
+      }
+
+      const failed = error !== undefined || code !== 0;
+      const detail = error !== undefined
+        ? error.message
+        : signal !== null
+          ? `signal ${signal}`
+          : `code ${code ?? "unknown"}`;
+      stderr.write(
+        `[studio] ${source.name} exited (${detail}); stopping the other process.\n`,
+      );
+      resolveExit(failed ? 1 : 0);
+    };
+
+    for (const source of children) {
+      source.child.once("error", (error) => settle(source, null, null, error));
+      source.child.once("exit", (code, signal) => settle(source, code, signal));
+    }
+  });
+}
+
+export function startStudioChildren({
+  spawnProcess = spawn,
+  nodeExecutable = process.execPath,
+  pnpmExecutable = process.env.npm_execpath,
+} = {}) {
+  if (pnpmExecutable === undefined || pnpmExecutable.length === 0) {
+    throw new Error("pnpm studio must be launched through pnpm");
+  }
+
+  const launch = (name, packageName, command) => ({
+    name,
+    child: spawnProcess(
+      nodeExecutable,
+      [pnpmExecutable, "--filter", packageName, ...command],
+      {
+        cwd: repositoryRoot,
+        env: process.env,
+        stdio: "inherit",
+        detached: process.platform !== "win32",
+      },
+    ),
+  });
+
+  return [
+    launch("control plane", "@pmh/control-plane", ["exec", "tsx", "src/main.ts"]),
+    launch("Studio", "@pmh/studio", ["dev"]),
+  ];
+}

--- a/scripts/studio-supervisor.test.mjs
+++ b/scripts/studio-supervisor.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { createServer } from "node:net";
+import test from "node:test";
+
+import {
+  assertPortAvailable,
+  startStudioChildren,
+  superviseStudio,
+} from "./studio-supervisor.mjs";
+
+function fakeChild(pid) {
+  const child = new EventEmitter();
+  child.pid = pid;
+  child.exitCode = null;
+  child.signalCode = null;
+  child.killSignals = [];
+  child.kill = (signal) => child.killSignals.push(signal);
+  return child;
+}
+
+test("stops Studio and fails when the control plane cannot bind", async () => {
+  const controlPlane = fakeChild();
+  const studio = fakeChild();
+  const diagnostics = [];
+  const result = superviseStudio([
+    { name: "control plane", child: controlPlane },
+    { name: "Studio", child: studio },
+  ], { stderr: { write: (value) => diagnostics.push(value) } });
+
+  controlPlane.emit("exit", 1, null);
+
+  assert.equal(await result, 1);
+  assert.deepEqual(studio.killSignals, ["SIGTERM"]);
+  assert.match(diagnostics.join(""), /control plane exited \(code 1\)/);
+});
+
+test("stops the control plane when Studio exits cleanly", async () => {
+  const controlPlane = fakeChild();
+  const studio = fakeChild();
+  const result = superviseStudio([
+    { name: "control plane", child: controlPlane },
+    { name: "Studio", child: studio },
+  ], { stderr: { write() {} } });
+
+  studio.emit("exit", 0, null);
+
+  assert.equal(await result, 0);
+  assert.deepEqual(controlPlane.killSignals, ["SIGTERM"]);
+});
+
+test("treats a child spawn error as a failed unit", async () => {
+  const controlPlane = fakeChild();
+  const studio = fakeChild();
+  const result = superviseStudio([
+    { name: "control plane", child: controlPlane },
+    { name: "Studio", child: studio },
+  ], { stderr: { write() {} } });
+
+  studio.emit("error", new Error("spawn failed"));
+
+  assert.equal(await result, 1);
+  assert.deepEqual(controlPlane.killSignals, ["SIGTERM"]);
+});
+
+test("rejects before either child starts when port 4100 is occupied", async () => {
+  const occupant = createServer();
+  await new Promise((resolveListen) => occupant.listen(0, "127.0.0.1", resolveListen));
+  const address = occupant.address();
+  assert.ok(address !== null && typeof address === "object");
+
+  await assert.rejects(
+    assertPortAvailable({ port: address.port }),
+    /control-plane port .* is already in use/,
+  );
+  await new Promise((resolveClose) => occupant.close(resolveClose));
+});
+
+test("runs the control plane without a watcher that can hide startup failure", () => {
+  const calls = [];
+  startStudioChildren({
+    nodeExecutable: "/node",
+    pnpmExecutable: "/pnpm.cjs",
+    spawnProcess: (...args) => {
+      calls.push(args);
+      return fakeChild();
+    },
+  });
+
+  assert.deepEqual(calls.map(([executable, args]) => [executable, args]), [
+    ["/node", ["/pnpm.cjs", "--filter", "@pmh/control-plane", "exec", "tsx", "src/main.ts"]],
+    ["/node", ["/pnpm.cjs", "--filter", "@pmh/studio", "dev"]],
+  ]);
+});

--- a/scripts/studio.mjs
+++ b/scripts/studio.mjs
@@ -1,0 +1,29 @@
+import {
+  assertPortAvailable,
+  startStudioChildren,
+  stopChild,
+  superviseStudio,
+} from "./studio-supervisor.mjs";
+
+async function main() {
+  await assertPortAvailable();
+  const children = startStudioChildren();
+  let shuttingDown = false;
+
+  for (const signal of ["SIGINT", "SIGTERM"]) {
+    process.once(signal, () => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      for (const { child } of children) stopChild(child, signal);
+    });
+  }
+
+  return superviseStudio(children);
+}
+
+try {
+  process.exitCode = await main();
+} catch (error) {
+  process.stderr.write(`[studio] ${error.message}\n`);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Why

A clean-origin/main first-time-user audit used one retained Grok Build session: 01a01dc2-1618-7853-984b-ba85974960eb. Install, workspace checks, and tests passed, but the audit reproduced a misleading partial startup when port 4100 was occupied: the control plane failed while its watcher and Vite remained alive. It also found that the README walkthrough had drifted from the released Studio navigation.

## Changes

- supervise the control plane and Studio as one pnpm studio process unit
- reject an occupied control-plane port before either child starts
- run the control plane without a watcher that can hide a startup failure
- add focused supervisor and occupied-port regression tests
- align README and operations guidance with the current Discover-first UI
- record the retained Grok session and evidence policy in PLANS.md

## Verification

- pnpm check
- pnpm test (5 supervisor tests, 794 control-plane tests, 30 Studio tests, and the remaining workspace suites)
- pnpm studio:build
- git diff --check
- manual occupied-port regression: pnpm studio exits nonzero before Vite starts

## Audit notes

The Grok topic session was reused and compacted rather than replaced. Its prose claimed edits that were not present in Git, so Git state and command output were treated as the acceptance evidence. A final headless review attempt stalled while creating the session; Codex independently reviewed the diff and ran the full validation above.

No live-order, credential, signing, or value-moving behavior changes.