### PR TITLE
feat: add external Agent operator surface

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -17,6 +17,16 @@ current empty-first-run navigation. Future audits for this topic should resume
 and compact that session, but Git state and command results—not Agent prose—are
 the acceptance evidence.
 
+The selected usability continuation is
+[`plans/external-agent-operator-surface.md`](plans/external-agent-operator-surface.md).
+Auto Prediction now treats the internal research Agent and the external
+operator Agent as separate first-class layers. The first mainline slice makes
+`pmh` self-describing, connects it to startup readiness and a bounded Agent
+workspace, and preserves stable recovery diagnostics without copying
+control-plane verdict logic. The next slice must turn one exact routed target
+into a previewable external-Agent workflow and measure time/context to the first
+valid action.
+
 The product brand is **Auto Prediction**, paired conceptually with Auto Quant.
 The rename is presentation-only for now: `pmh` CLI, package scopes, environment
 variables, and content-addressed protocol/schema identifiers remain stable

--- a/README.md
+++ b/README.md
@@ -118,6 +118,23 @@ reported explicitly rather than silently falling back.
 For environment settings, persistent scheduling, provider selection, and
 smoke commands, read [Operations](docs/OPERATIONS.md).
 
+### External Agent quick start
+
+Studio is optional for machine operators. An external Agent can discover the
+versioned local surface, verify the control plane, and read bounded routing
+state without scraping the UI:
+
+```bash
+pnpm --silent pmh
+pnpm --silent pmh control status
+pnpm --silent pmh agent workspace
+```
+
+`--silent` keeps stdout to one JSON envelope; build diagnostics remain on
+stderr. Every command includes stable diagnostics and `allowedNextActions`.
+Follow those actions rather than guessing HTTP routes. See [CLI](docs/CLI.md)
+for endpoint overrides and failure semantics.
+
 ## First use
 
 1. Studio opens on **Discover**. Before spending model budget, open **System

--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -6055,6 +6055,29 @@ function Overview({
         <Metric label="Order execution" value="Disabled" detail="research workspace" />
       </section>
 
+      <section className="external-agent-access" aria-label="External Agent access">
+        <div className="external-agent-access-heading">
+          <span className="external-agent-access-icon"><Bot size={17} /></span>
+          <div>
+            <span className="eyebrow">External operator surface</span>
+            <strong>Agents can operate without scraping Studio</strong>
+            <p>
+              The versioned CLI reads the same local control plane and returns
+              bounded JSON, stable failures, and exact next actions.
+            </p>
+          </div>
+        </div>
+        <div className="external-agent-commands" aria-label="Agent CLI entry points">
+          <code>pnpm --silent pmh</code>
+          <code>pnpm --silent pmh control status</code>
+          <code>pnpm --silent pmh agent workspace</code>
+        </div>
+        <div className="external-agent-access-meta">
+          <Badge variant="verified">JSON · pmh.cli.v1</Badge>
+          <span>127.0.0.1:4100 · no live execution</span>
+        </div>
+      </section>
+
       <section className="ai-rack" aria-label="AI discovery workers">
         <div className="ai-rack-header">
           <div className="ai-rack-heading">

--- a/apps/studio/src/product-shell.css
+++ b/apps/studio/src/product-shell.css
@@ -2752,6 +2752,112 @@ footer {
   }
 }
 
+/* The product has an internal research-Agent layer and an external operator-
+ * Agent layer. Keep the machine entry point visible without turning Studio
+ * into terminal documentation. */
+.external-agent-access {
+  display: grid;
+  grid-template-columns: minmax(300px, 1.25fr) minmax(320px, 1fr) auto;
+  align-items: center;
+  gap: 22px;
+  margin-top: 14px;
+  border: 1px solid rgba(120, 217, 181, 0.2);
+  border-radius: 10px;
+  background: linear-gradient(110deg, rgba(120, 217, 181, 0.065), #101416 58%);
+  padding: 16px 18px;
+}
+
+.external-agent-access-heading {
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.external-agent-access-icon {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid rgba(120, 217, 181, 0.24);
+  border-radius: 8px;
+  background: rgba(120, 217, 181, 0.08);
+  color: var(--primary);
+}
+
+.external-agent-access-heading > div {
+  display: grid;
+  gap: 3px;
+}
+
+.external-agent-access-heading strong {
+  font-size: 14px;
+  font-weight: 610;
+}
+
+.external-agent-access-heading p {
+  margin: 0;
+  color: #8f9894;
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+
+.external-agent-commands {
+  display: grid;
+  min-width: 0;
+  gap: 5px;
+}
+
+.external-agent-commands code {
+  overflow: hidden;
+  border: 1px solid #282f32;
+  border-radius: 6px;
+  background: #0b0e10;
+  padding: 6px 9px;
+  color: #c8d1cd;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 11.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.external-agent-access-meta {
+  display: grid;
+  justify-items: end;
+  gap: 7px;
+  white-space: nowrap;
+}
+
+.external-agent-access-meta span {
+  color: #747d79;
+  font-size: 11.5px;
+}
+
+@media (max-width: 1180px) {
+  .external-agent-access {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .external-agent-access-meta {
+    grid-column: 1 / -1;
+    grid-template-columns: auto 1fr;
+    align-items: center;
+    justify-items: start;
+  }
+}
+
+@media (max-width: 760px) {
+  .external-agent-access {
+    grid-template-columns: 1fr;
+  }
+
+  .external-agent-access-meta {
+    grid-column: auto;
+    grid-template-columns: 1fr;
+  }
+}
+
 .agent-console {
   display: grid;
   gap: 20px;

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,22 +1,61 @@
 # CLI
 
 For installation and process startup, see [Operations](OPERATIONS.md). The CLI
-is a narrow machine-readable inspection surface; Auto Prediction Studio remains the
-primary operator interface.
+is the machine-readable operator surface for external Agents. Auto Prediction
+Studio remains the human observability surface; both read the same first-party
+control-plane projections.
 
 The bundled `pmh` CLI emits schema `pmh.cli.v1`. Every response contains command identity, current state, diagnostics, an explicit no-side-effects declaration, content-hashed artifacts, allowed next actions, and an `ok` verdict.
+
+Begin with no arguments or `help`. This does not require a running control
+plane and returns the exact command catalog and valid next actions:
+
+```bash
+pnpm --silent pmh
+pnpm --silent pmh help
+```
 
 Implemented commands:
 
 ```bash
-pnpm pmh system status
-pnpm pmh venue list
-pnpm pmh venue inspect <venue-id>
+pnpm --silent pmh help
+pnpm --silent pmh system status
+pnpm --silent pmh control status
+pnpm --silent pmh agent workspace
+pnpm --silent pmh venue list
+pnpm --silent pmh venue inspect <venue-id>
 ```
+
+`control status` reads the versioned startup-readiness projection. `agent
+workspace` reads `/api/v1/agent-workspace/routing`, a first-party bounded
+projection: execution counts and retained capability outcomes, the first 12
+attention actions and research targets, relation-campaign eligibility, and
+discovery-cycle state. It retains exact task/action/target identities needed
+for later commands and never downloads the multi-megabyte Studio workspace or
+copies semantic or economic verdict logic into the CLI.
+
+The default control plane is `http://127.0.0.1:4100`. Override it for another
+local or tunneled environment without changing command output:
+
+```bash
+PMH_CONTROL_PLANE_URL=http://127.0.0.1:14100 pnpm --silent pmh control status
+```
+
+Use `--silent` for machine consumption: stdout is then exactly one JSON
+envelope. The root launcher incrementally builds only the CLI and its referenced
+packages instead of rebuilding the whole monorepo; compiler diagnostics remain
+on stderr.
+
+Control-plane reads have a 30-second bounded timeout and fail with stable diagnostic
+codes: `CONTROL_PLANE_UNREACHABLE`, `CONTROL_PLANE_TIMEOUT`,
+`CONTROL_PLANE_HTTP_ERROR`, or `CONTROL_PLANE_MALFORMED_RESPONSE`. The envelope
+always includes valid recovery commands in `allowedNextActions`; external
+Agents should follow that field rather than guessing a route.
 
 Unknown commands and venue identities fail closed with a non-zero process exit code and a JSON diagnostic. The present CLI cannot write external state or move value; both effects are literal `false` in every response.
 
-Claim/link inspection, opportunity verification, deterministic replay, shadow
-execution, campaign inspection, and Core projections remain planned CLI
-surfaces. Human-readable Studio views consume control-plane projections and
-must never recompute verdicts.
+Exact target/task inspection, previewable manual runs, campaign control,
+catalog refresh, claim/link inspection, opportunity verification,
+deterministic replay, shadow execution, and Core projections remain planned CLI
+surfaces. Human-readable Studio views and compact CLI views consume
+control-plane projections and must never recompute verdicts.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -30,10 +30,18 @@ Useful health checks:
 
 ```bash
 curl --fail http://127.0.0.1:4100/health
-pnpm pmh system status
-pnpm pmh venue list
-pnpm pmh venue inspect polymarket-global
+pnpm --silent pmh system status
+pnpm --silent pmh control status
+pnpm --silent pmh agent workspace
+pnpm --silent pmh venue list
+pnpm --silent pmh venue inspect polymarket-global
 ```
+
+The last commands are also the external-Agent quick start. With `--silent`,
+stdout contains one versioned JSON envelope and build diagnostics stay on
+stderr. `agent workspace` returns the bounded routing projection rather than
+the much larger Studio workspace. See [CLI](CLI.md) for its stable failure
+codes and endpoint override.
 
 ## Local state
 

--- a/docs/STUDIO.md
+++ b/docs/STUDIO.md
@@ -294,3 +294,9 @@ starting a campaign. Catalog refresh is anonymous and does not call a model.
 Agent work begins only through an explicit action or an enabled durable
 scheduler. The selected provider, runtime capability, model, reasoning effort,
 campaign state, and usage lineage remain visible in Studio.
+
+Studio is not a machine-control API. External Agents should begin with
+`pnpm --silent pmh`, then use `control status` and `agent workspace`. The latter
+reads the dedicated bounded `GET /api/v1/agent-workspace/routing` projection;
+it preserves the exact identities needed to choose a next action without
+serializing the multi-megabyte human workspace or scraping this interface.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "rule-evidence-claim:smoke": "pnpm --filter @pmh/control-plane smoke:rule-evidence-claim",
     "fixtures:capture": "node scripts/capture-public-fixtures.mjs",
     "fixtures:capture:streams": "node scripts/capture-public-stream-fixtures.mjs",
-    "pmh": "pnpm -r build && node packages/cli/dist/main.js",
+    "pmh": "pnpm --silent --filter @pmh/cli build && node packages/cli/dist/main.js",
     "studio": "node scripts/studio.mjs",
     "studio:build": "pnpm --filter @pmh/control-plane build && pnpm --filter @pmh/studio build",
     "test": "node --test scripts/studio-supervisor.test.mjs && pnpm -r test",

--- a/packages/cli/src/control-plane-client.ts
+++ b/packages/cli/src/control-plane-client.ts
@@ -1,0 +1,114 @@
+export const DEFAULT_CONTROL_PLANE_URL = "http://127.0.0.1:4100";
+export const DEFAULT_CONTROL_PLANE_TIMEOUT_MS = 30_000;
+
+export type ControlPlaneDiagnosticCode =
+  | "CONTROL_PLANE_UNREACHABLE"
+  | "CONTROL_PLANE_TIMEOUT"
+  | "CONTROL_PLANE_HTTP_ERROR"
+  | "CONTROL_PLANE_MALFORMED_RESPONSE";
+
+export class ControlPlaneRequestError extends Error {
+  public readonly code: ControlPlaneDiagnosticCode;
+
+  public constructor(code: ControlPlaneDiagnosticCode, message: string) {
+    super(message);
+    this.name = "ControlPlaneRequestError";
+    this.code = code;
+  }
+}
+
+export type ControlPlaneClientOptions = Readonly<{
+  baseUrl?: string;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}>;
+
+function normalizedBaseUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      throw new Error("unsupported protocol");
+    }
+    return url.toString().replace(/\/$/u, "");
+  } catch {
+    throw new ControlPlaneRequestError(
+      "CONTROL_PLANE_UNREACHABLE",
+      `Control-plane URL is invalid: ${value}`,
+    );
+  }
+}
+
+function responseDiagnostic(value: unknown): string | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const diagnostic = (value as Record<string, unknown>).diagnostic;
+  return typeof diagnostic === "string" ? diagnostic : null;
+}
+
+export async function requestControlPlaneJson(
+  path: `/${string}`,
+  options: ControlPlaneClientOptions & Readonly<{
+    acceptedStatuses?: readonly number[];
+  }> = {},
+): Promise<Readonly<{ baseUrl: string; status: number; value: unknown }>> {
+  const baseUrl = normalizedBaseUrl(
+    options.baseUrl ?? process.env.PMH_CONTROL_PLANE_URL ??
+      DEFAULT_CONTROL_PLANE_URL,
+  );
+  const timeoutMs = options.timeoutMs ?? DEFAULT_CONTROL_PLANE_TIMEOUT_MS;
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1) {
+    throw new ControlPlaneRequestError(
+      "CONTROL_PLANE_TIMEOUT",
+      "Control-plane timeout must be a positive integer number of milliseconds.",
+    );
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  let response: Response;
+  try {
+    response = await (options.fetchImpl ?? fetch)(`${baseUrl}${path}`, {
+      headers: { accept: "application/json" },
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new ControlPlaneRequestError(
+        "CONTROL_PLANE_TIMEOUT",
+        `Control plane did not respond within ${timeoutMs} ms at ${baseUrl}.`,
+      );
+    }
+    throw new ControlPlaneRequestError(
+      "CONTROL_PLANE_UNREACHABLE",
+      `Control plane is unreachable at ${baseUrl}: ${
+        error instanceof Error ? error.message : "request failed"
+      }`,
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  let value: unknown;
+  try {
+    value = JSON.parse(await response.text()) as unknown;
+  } catch {
+    throw new ControlPlaneRequestError(
+      "CONTROL_PLANE_MALFORMED_RESPONSE",
+      `Control plane returned non-JSON content for ${path}.`,
+    );
+  }
+
+  const acceptedStatuses = options.acceptedStatuses ?? Object.freeze([200]);
+  if (!acceptedStatuses.includes(response.status)) {
+    const detail = responseDiagnostic(value);
+    throw new ControlPlaneRequestError(
+      "CONTROL_PLANE_HTTP_ERROR",
+      `Control plane returned HTTP ${response.status} for ${path}${
+        detail === null ? "." : `: ${detail}`
+      }`,
+    );
+  }
+
+  return Object.freeze({ baseUrl, status: response.status, value });
+}

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -1,11 +1,141 @@
 import { createCliEnvelope, type CliEnvelope } from "./envelope.js";
+import {
+  ControlPlaneRequestError,
+  requestControlPlaneJson,
+  type ControlPlaneClientOptions,
+} from "./control-plane-client.js";
 import { venueRegistry } from "./registry.js";
 
-const SUPPORTED_COMMANDS = [
+export const SUPPORTED_COMMANDS = Object.freeze([
+  "help",
   "system status",
+  "control status",
+  "agent workspace",
   "venue list",
   "venue inspect <venue-id>",
-] as const;
+] as const);
+
+const COMMAND_CATALOG = Object.freeze([
+  Object.freeze({
+    command: "help",
+    kind: "LOCAL_INSPECTION",
+    description: "Discover this version's exact machine-readable command surface.",
+    requiresControlPlane: false,
+  }),
+  Object.freeze({
+    command: "system status",
+    kind: "LOCAL_INSPECTION",
+    description: "Inspect build-time venue coverage and the runtime boundary.",
+    requiresControlPlane: false,
+  }),
+  Object.freeze({
+    command: "control status",
+    kind: "CONTROL_PLANE_READ",
+    description: "Read startup readiness from the local control plane.",
+    requiresControlPlane: true,
+  }),
+  Object.freeze({
+    command: "agent workspace",
+    kind: "CONTROL_PLANE_READ",
+    description: "Read a compact routing view of Agent work and execution state.",
+    requiresControlPlane: true,
+  }),
+  Object.freeze({
+    command: "venue list",
+    kind: "LOCAL_INSPECTION",
+    description: "List registered venue protocol identities.",
+    requiresControlPlane: false,
+  }),
+  Object.freeze({
+    command: "venue inspect <venue-id>",
+    kind: "LOCAL_INSPECTION",
+    description: "Inspect one validated venue capability manifest.",
+    requiresControlPlane: false,
+  }),
+]);
+
+type JsonObject = Record<string, unknown>;
+
+function objectValue(value: unknown): JsonObject | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as JsonObject
+    : null;
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function numberValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function malformedControlPlaneEnvelope(
+  command: string,
+  path: string,
+): CliEnvelope {
+  return createCliEnvelope({
+    command,
+    arguments: [],
+    state: null,
+    diagnostics: [{
+      severity: "ERROR",
+      code: "CONTROL_PLANE_MALFORMED_RESPONSE",
+      message: `Control plane returned an incompatible payload for ${path}.`,
+    }],
+    allowedNextActions: ["control status", "help"],
+    ok: false,
+  });
+}
+
+function controlPlaneFailure(
+  command: string,
+  error: unknown,
+): CliEnvelope {
+  const diagnostic = error instanceof ControlPlaneRequestError
+    ? error
+    : new ControlPlaneRequestError(
+      "CONTROL_PLANE_UNREACHABLE",
+      error instanceof Error ? error.message : "Control-plane request failed.",
+    );
+  return createCliEnvelope({
+    command,
+    arguments: [],
+    state: null,
+    diagnostics: [{
+      severity: "ERROR",
+      code: diagnostic.code,
+      message: diagnostic.message,
+    }],
+    allowedNextActions: ["control status", "help"],
+    ok: false,
+  });
+}
+
+function validateAgentOperatorWorkspace(value: unknown) {
+  const workspace = objectValue(value);
+  const execution = objectValue(workspace?.execution);
+  const attention = objectValue(workspace?.attention);
+  const targets = objectValue(workspace?.targets);
+  const discoveryCycle = objectValue(workspace?.discoveryCycle);
+  if (
+    workspace?.schemaVersion !== "pmh.agent-operator-workspace.v1" ||
+    execution?.schemaVersion !== "pmh.agent-execution-registry.v1" ||
+    attention?.schemaVersion !== "pmh.research-attention-allocation.v1" ||
+    targets?.schemaVersion !== "pmh.research-action-target-projection.v1" ||
+    discoveryCycle?.schemaVersion !== "pmh.discovery-cycle.v1" ||
+    execution.credentialSecretTextRetained !== false ||
+    workspace.providerRequestsStartedByRead !== 0 ||
+    workspace.modelInvocationsStartedByRead !== 0 ||
+    workspace.writesStartedByRead !== 0 ||
+    workspace.automaticDispatch !== false ||
+    workspace.semanticDecisionAuthority !== false ||
+    workspace.certificateAuthority !== false ||
+    workspace.externalWriteAuthority !== false ||
+    workspace.valueMovingAuthority !== false
+  ) return null;
+  return workspace;
+}
 
 function commandNotFound(argv: readonly string[]): CliEnvelope {
   return createCliEnvelope({
@@ -24,8 +154,36 @@ function commandNotFound(argv: readonly string[]): CliEnvelope {
   });
 }
 
-export function runCli(argv: readonly string[]): CliEnvelope {
+export async function runCli(
+  argv: readonly string[],
+  options: ControlPlaneClientOptions = {},
+): Promise<CliEnvelope> {
   const [namespace, action, venueId, ...extra] = argv;
+
+  if (
+    argv.length === 0 ||
+    (namespace === "help" && action === undefined) ||
+    (namespace === "--help" && action === undefined)
+  ) {
+    return createCliEnvelope({
+      command: "help",
+      arguments: [],
+      state: {
+        product: "Auto Prediction",
+        interface: "pmh.cli.v1",
+        controlPlaneUrl:
+          options.baseUrl ?? process.env.PMH_CONTROL_PLANE_URL ??
+          "http://127.0.0.1:4100",
+        commands: COMMAND_CATALOG,
+        environment: Object.freeze({
+          PMH_CONTROL_PLANE_URL:
+            "Optional HTTP(S) base URL; defaults to http://127.0.0.1:4100",
+        }),
+      },
+      allowedNextActions: SUPPORTED_COMMANDS.filter((item) => item !== "help"),
+      ok: true,
+    });
+  }
 
   if (namespace === "system" && action === "status" && venueId === undefined) {
     const venues = [...venueRegistry.values()];
@@ -58,7 +216,7 @@ export function runCli(argv: readonly string[]): CliEnvelope {
         ),
         liveExecutionEnabled: false,
         runtimeTarget: {
-          node: ">=24",
+          node: ">=22.19",
           pnpm: "11.13.1",
         },
       },
@@ -69,9 +227,90 @@ export function runCli(argv: readonly string[]): CliEnvelope {
           message: "The harness has no live-order authority.",
         },
       ],
-      allowedNextActions: ["venue list", "venue inspect <venue-id>"],
+      allowedNextActions: [
+        "control status",
+        "agent workspace",
+        "venue list",
+        "venue inspect <venue-id>",
+      ],
       ok: true,
     });
+  }
+
+  if (namespace === "control" && action === "status" && venueId === undefined) {
+    try {
+      const result = await requestControlPlaneJson("/api/v1/readiness", {
+        ...options,
+        acceptedStatuses: [200, 202, 503],
+      });
+      const readiness = objectValue(result.value);
+      if (
+        readiness?.schemaVersion !== "pmh.startup-readiness.v1" ||
+        !["STARTING", "READY", "FAILED"].includes(String(readiness.status)) ||
+        readiness.externalWriteAuthority !== false ||
+        readiness.valueMovingAuthority !== false
+      ) return malformedControlPlaneEnvelope("control.status", "/api/v1/readiness");
+
+      const ready = readiness.status === "READY";
+      const diagnostics = ready ? [] : [{
+        severity: readiness.status === "FAILED" ? "ERROR" as const : "WARNING" as const,
+        code: readiness.status === "FAILED"
+          ? "CONTROL_PLANE_STARTUP_FAILED"
+          : "CONTROL_PLANE_STARTING",
+        message: stringValue(readiness.diagnostic) ??
+          `Control plane is ${String(readiness.status).toLowerCase()} in ${String(readiness.phase)}.`,
+      }];
+      return createCliEnvelope({
+        command: "control.status",
+        arguments: [],
+        state: Object.freeze({
+          schemaVersion: readiness.schemaVersion,
+          controlPlaneUrl: result.baseUrl,
+          status: readiness.status,
+          phase: stringValue(readiness.phase),
+          elapsedMs: numberValue(readiness.elapsedMs),
+          phaseElapsedMs: numberValue(readiness.phaseElapsedMs),
+          currentReconciliationStep:
+            stringValue(readiness.currentReconciliationStep),
+          diagnostic: stringValue(readiness.diagnostic),
+          workspaceResource: "/api/v1/agent-workspace/routing",
+          externalWriteAuthority: false as const,
+          valueMovingAuthority: false as const,
+        }),
+        diagnostics,
+        allowedNextActions: ready
+          ? ["agent workspace", "help"]
+          : ["control status", "help"],
+        ok: ready,
+      });
+    } catch (error) {
+      return controlPlaneFailure("control.status", error);
+    }
+  }
+
+  if (namespace === "agent" && action === "workspace" && venueId === undefined) {
+    try {
+      const result = await requestControlPlaneJson(
+        "/api/v1/agent-workspace/routing",
+        options,
+      );
+      const workspace = validateAgentOperatorWorkspace(result.value);
+      if (workspace === null) {
+        return malformedControlPlaneEnvelope(
+          "agent.workspace",
+          "/api/v1/agent-workspace/routing",
+        );
+      }
+      return createCliEnvelope({
+        command: "agent.workspace",
+        arguments: [],
+        state: Object.freeze({ ...workspace, controlPlaneUrl: result.baseUrl }),
+        allowedNextActions: ["control status", "agent workspace", "help"],
+        ok: true,
+      });
+    } catch (error) {
+      return controlPlaneFailure("agent.workspace", error);
+    }
   }
 
   if (namespace === "venue" && action === "list" && venueId === undefined) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./control-plane-client.js";
 export * from "./dispatch.js";
 export * from "./envelope.js";
 export * from "./registry.js";

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -2,7 +2,7 @@
 
 import { runCli } from "./dispatch.js";
 
-const envelope = runCli(process.argv.slice(2));
+const envelope = await runCli(process.argv.slice(2));
 process.stdout.write(`${JSON.stringify(envelope, null, 2)}\n`);
 if (!envelope.ok) {
   process.exitCode = 2;

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -1,9 +1,52 @@
-import { describe, expect, it } from "vitest";
+import { createServer, type Server } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
 import { CLI_SCHEMA_VERSION, runCli } from "../src/index.js";
 
+const servers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) =>
+    new Promise<void>((resolve) => server.close(() => resolve()))
+  ));
+});
+
+async function serve(
+  handler: Parameters<typeof createServer>[0],
+): Promise<string> {
+  const server = createServer(handler);
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("test server did not bind a TCP port");
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
+function json(
+  response: Parameters<NonNullable<Parameters<typeof createServer>[0]>>[1],
+  value: unknown,
+  status = 200,
+) {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(value));
+}
+
 describe("versioned CLI envelope", () => {
-  it("reports the system's pre-alpha and live-disabled boundary", () => {
-    const result = runCli(["system", "status"]);
+  it("discovers the exact command surface without a running control plane", async () => {
+    const result = await runCli([]);
+    expect(result.schemaVersion).toBe(CLI_SCHEMA_VERSION);
+    expect(result.ok).toBe(true);
+    expect(result.identity.command).toBe("help");
+    expect(result.state).toMatchObject({
+      product: "Auto Prediction",
+      interface: "pmh.cli.v1",
+    });
+    expect(result.allowedNextActions).toContain("agent workspace");
+  });
+
+  it("reports the system's Node 22 baseline and live-disabled boundary", async () => {
+    const result = await runCli(["system", "status"]);
     expect(result.schemaVersion).toBe(CLI_SCHEMA_VERSION);
     expect(result.ok).toBe(true);
     expect(result.effects).toEqual({
@@ -11,12 +54,201 @@ describe("versioned CLI envelope", () => {
       valueMovingActions: false,
       liveExecutionEnabled: false,
     });
+    expect(result.state).toMatchObject({ runtimeTarget: { node: ">=22.19" } });
     expect(result.artifacts[0]?.contentHash).toMatch(/^sha256:[0-9a-f]{64}$/);
     expect(() => JSON.stringify(result)).not.toThrow();
   });
 
-  it("inspects validated venue capability evidence", () => {
-    const result = runCli(["venue", "inspect", "polymarket-global"]);
+  it("reads startup readiness from a local control plane", async () => {
+    const baseUrl = await serve((_request, response) => json(response, {
+      schemaVersion: "pmh.startup-readiness.v1",
+      status: "READY",
+      phase: "READY",
+      elapsedMs: 42,
+      phaseElapsedMs: 3,
+      currentReconciliationStep: null,
+      diagnostic: null,
+      externalWriteAuthority: false,
+      valueMovingAuthority: false,
+    }));
+
+    const result = await runCli(["control", "status"], { baseUrl });
+    expect(result.ok).toBe(true);
+    expect(result.state).toMatchObject({
+      status: "READY",
+      controlPlaneUrl: baseUrl,
+      workspaceResource: "/api/v1/agent-workspace/routing",
+    });
+    expect(result.allowedNextActions).toContain("agent workspace");
+  });
+
+  it("compresses the Agent workspace into bounded routing state", async () => {
+    const baseUrl = await serve((request, response) => {
+      expect(request.url).toBe("/api/v1/agent-workspace/routing");
+      json(response, {
+        schemaVersion: "pmh.agent-operator-workspace.v1",
+        execution: {
+          schemaVersion: "pmh.agent-execution-registry.v1",
+          runtimeDefinitionCount: 3,
+          executionProfileCount: 2,
+          taskCount: 7,
+          runCount: 5,
+          activeCampaignCount: 1,
+          capabilityObservationCount: 2,
+          capabilityOutcomeCounts: { USABLE: 1, REJECTED: 1 },
+          credentialSecretTextRetained: false,
+        },
+        attention: {
+          schemaVersion: "pmh.research-attention-allocation.v1",
+          projectionIdentity: "sha256:attention",
+          familyCount: 4,
+          actionableFamilyCount: 1,
+          heldFamilyCount: 3,
+          laneCounts: { exploration: 1 },
+          nextWork: [{
+            actionId: "sha256:action",
+            lane: "EXPLORATION",
+            kind: "RUN",
+            taskId: "sha256:task",
+            valueStage: "DISCOVERY",
+            dispatchableByRelationCampaign: true,
+          }],
+          nextWorkTruncated: false,
+        },
+        targets: {
+          schemaVersion: "pmh.research-action-target-projection.v1",
+          targetCount: 8,
+          readyCount: 2,
+          inFlightCount: 1,
+          blockedNegativeSearchCount: 3,
+          unresolvedCount: 2,
+          nextTargets: [{
+            targetId: "sha256:target",
+            allocationActionId: "sha256:action",
+            state: "READY_RELATION_DISCOVERY",
+            downstreamSystem: "RELATION_DISCOVERY",
+            sourceTaskId: "sha256:task",
+            currentJobId: null,
+            manualOperation: {
+              available: true,
+              kind: "RELATION_DISCOVERY_TASK",
+              targetId: "sha256:task",
+            },
+            diagnostic: "ready",
+          }],
+          nextTargetsTruncated: true,
+        },
+        relationCampaign: {
+          schemaVersion: "pmh.relation-discovery-campaign-preview.v1",
+          campaignKey: "relation",
+          taskIds: ["sha256:task"],
+          creationEligible: true,
+          dispatchEligible: false,
+          diagnostic: "paused",
+        },
+        discoveryCycle: {
+          schemaVersion: "pmh.discovery-cycle.v1",
+          enabled: true,
+          intervalMs: 60_000,
+          tickCount: 9,
+          lastCompletedAt: "2026-08-20T00:00:00.000Z",
+          lastDiagnostic: null,
+        },
+        providerRequestsStartedByRead: 0,
+        modelInvocationsStartedByRead: 0,
+        writesStartedByRead: 0,
+        automaticDispatch: false,
+        semanticDecisionAuthority: false,
+        certificateAuthority: false,
+        externalWriteAuthority: false,
+        valueMovingAuthority: false,
+      });
+    });
+
+    const result = await runCli(["agent", "workspace"], { baseUrl });
+    expect(result.ok).toBe(true);
+    expect(result.state).toMatchObject({
+      schemaVersion: "pmh.agent-operator-workspace.v1",
+      execution: {
+        taskCount: 7,
+        capabilityOutcomeCounts: { USABLE: 1, REJECTED: 1 },
+      },
+      attention: {
+        actionableFamilyCount: 1,
+        nextWork: [{ actionId: "sha256:action", taskId: "sha256:task" }],
+      },
+      targets: {
+        readyCount: 2,
+        nextTargets: [{ targetId: "sha256:target", state: "READY_RELATION_DISCOVERY" }],
+      },
+    });
+  });
+
+  it("returns stable recovery diagnostics for an unreachable control plane", async () => {
+    const result = await runCli(["control", "status"], {
+      baseUrl: "http://127.0.0.1:4100",
+      fetchImpl: async () => {
+        throw new TypeError("connection refused");
+      },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0]?.code).toBe("CONTROL_PLANE_UNREACHABLE");
+    expect(result.allowedNextActions).toEqual(["control status", "help"]);
+  });
+
+  it("distinguishes timeout from connection failure", async () => {
+    const baseUrl = await serve(() => {
+      // Deliberately retain the request until the client aborts it.
+    });
+    const result = await runCli(["control", "status"], {
+      baseUrl,
+      timeoutMs: 20,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0]?.code).toBe("CONTROL_PLANE_TIMEOUT");
+  });
+
+  it("retains an HTTP failure as a stable diagnostic", async () => {
+    const baseUrl = await serve((_request, response) => json(
+      response,
+      { ok: false, diagnostic: "workspace unavailable" },
+      503,
+    ));
+    const result = await runCli(["agent", "workspace"], { baseUrl });
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0]).toMatchObject({
+      code: "CONTROL_PLANE_HTTP_ERROR",
+      message: expect.stringContaining("workspace unavailable"),
+    });
+  });
+
+  it("rejects non-JSON control-plane content", async () => {
+    const baseUrl = await serve((_request, response) => {
+      response.writeHead(200, { "content-type": "text/html" });
+      response.end("<html>not the control plane</html>");
+    });
+    const result = await runCli(["agent", "workspace"], { baseUrl });
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0]?.code).toBe(
+      "CONTROL_PLANE_MALFORMED_RESPONSE",
+    );
+  });
+
+  it("rejects incompatible workspace JSON instead of guessing", async () => {
+    const baseUrl = await serve((_request, response) => json(response, {
+      schemaVersion: "unexpected",
+      externalWriteAuthority: false,
+      valueMovingAuthority: false,
+    }));
+    const result = await runCli(["agent", "workspace"], { baseUrl });
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0]?.code).toBe(
+      "CONTROL_PLANE_MALFORMED_RESPONSE",
+    );
+  });
+
+  it("inspects validated venue capability evidence", async () => {
+    const result = await runCli(["venue", "inspect", "polymarket-global"]);
     expect(result.ok).toBe(true);
     expect(result.state).toMatchObject({
       venueId: "polymarket-global",
@@ -24,12 +256,12 @@ describe("versioned CLI envelope", () => {
     });
   });
 
-  it("fails closed for unknown venues and commands", () => {
-    const missingVenue = runCli(["venue", "inspect", "unknown"]);
+  it("fails closed for unknown venues and commands", async () => {
+    const missingVenue = await runCli(["venue", "inspect", "unknown"]);
     expect(missingVenue.ok).toBe(false);
     expect(missingVenue.diagnostics[0]?.code).toBe("VENUE_NOT_FOUND");
 
-    const unknownCommand = runCli(["order", "submit"]);
+    const unknownCommand = await runCli(["order", "submit"]);
     expect(unknownCommand.ok).toBe(false);
     expect(unknownCommand.diagnostics[0]?.code).toBe(
       "CLI_COMMAND_NOT_FOUND",

--- a/packages/control-plane/src/server.ts
+++ b/packages/control-plane/src/server.ts
@@ -6633,6 +6633,114 @@ export function createControlPlane(options?: {
     }
     if (
       request.method === "GET" &&
+      url.pathname === "/api/v1/agent-workspace/routing"
+    ) {
+      await ready;
+      const research = currentResearchActionState();
+      const snapshot = agentExecutionRegistry.snapshot();
+      const execution = agentExecutionRegistry.projection();
+      const relationCampaign = await relationDiscoveryCampaignPreview(
+        research.allocation,
+      );
+      const capabilityOutcomeCounts = Object.fromEntries(
+        [...new Set(snapshot.capabilityObservations.map((item) => item.outcome))]
+          .sort()
+          .map((outcome) => [
+            outcome,
+            snapshot.capabilityObservations.filter((item) =>
+              item.outcome === outcome
+            ).length,
+          ]),
+      );
+      const nextWork = research.allocation.portfolio.slice(0, 12).map((item) =>
+        Object.freeze({
+          actionId: item.actionId,
+          lane: item.lane,
+          kind: item.kind,
+          workItemId: item.workItemId,
+          taskId: item.taskId,
+          valueStage: item.valueStage,
+          dispatchableByRelationCampaign: item.dispatchableByRelationCampaign,
+        })
+      );
+      const nextTargets = research.targets.targets.slice(0, 12).map((item) =>
+        Object.freeze({
+          targetId: item.targetId,
+          allocationActionId: item.allocationActionId,
+          state: item.state,
+          downstreamSystem: item.downstreamSystem,
+          sourceTaskId: item.sourceTaskId,
+          currentJobId: item.currentJobId,
+          manualOperation: item.manualOperation,
+          diagnostic: item.diagnostic,
+        })
+      );
+      writeJson(response, 200, Object.freeze({
+        schemaVersion: "pmh.agent-operator-workspace.v1" as const,
+        observedAt: research.allocation.observedAt,
+        execution: Object.freeze({
+          schemaVersion: execution.schemaVersion,
+          runtimeDefinitionCount: execution.runtimeDefinitionCount,
+          executionProfileCount: execution.executionProfileCount,
+          taskCount: execution.taskCount,
+          runCount: execution.runCount,
+          activeCampaignCount: execution.activeCampaignCount,
+          capabilityObservationCount: execution.capabilityObservationCount,
+          capabilityOutcomeCounts: Object.freeze(capabilityOutcomeCounts),
+          credentialSecretTextRetained: false as const,
+        }),
+        attention: Object.freeze({
+          schemaVersion: research.allocation.schemaVersion,
+          projectionIdentity: research.allocation.projectionIdentity,
+          familyCount: research.allocation.familyCount,
+          actionableFamilyCount: research.allocation.actionableFamilyCount,
+          heldFamilyCount: research.allocation.heldFamilyCount,
+          laneCounts: research.allocation.laneCounts,
+          nextWork: Object.freeze(nextWork),
+          nextWorkTruncated: research.allocation.portfolio.length > nextWork.length,
+        }),
+        targets: Object.freeze({
+          schemaVersion: research.targets.schemaVersion,
+          projectionIdentity: research.targets.projectionIdentity,
+          allocationProjectionIdentity:
+            research.targets.allocationProjectionIdentity,
+          targetCount: research.targets.targetCount,
+          readyCount: research.targets.readyCount,
+          inFlightCount: research.targets.inFlightCount,
+          blockedNegativeSearchCount: research.targets.blockedNegativeSearchCount,
+          unresolvedCount: research.targets.unresolvedCount,
+          nextTargets: Object.freeze(nextTargets),
+          nextTargetsTruncated: research.targets.targets.length > nextTargets.length,
+        }),
+        relationCampaign: Object.freeze({
+          schemaVersion: relationCampaign.schemaVersion,
+          campaignKey: relationCampaign.campaignKey,
+          taskIds: relationCampaign.taskIds,
+          creationEligible: relationCampaign.creationEligible,
+          dispatchEligible: relationCampaign.dispatchEligible,
+          diagnostic: relationCampaign.diagnostic,
+        }),
+        discoveryCycle: Object.freeze({
+          schemaVersion: discoveryCycleState.schemaVersion,
+          enabled: discoveryCycleState.enabled,
+          intervalMs: discoveryCycleState.intervalMs,
+          tickCount: discoveryCycleState.tickCount,
+          lastCompletedAt: discoveryCycleState.lastCompletedAt,
+          lastDiagnostic: discoveryCycleState.lastDiagnostic,
+        }),
+        providerRequestsStartedByRead: 0 as const,
+        modelInvocationsStartedByRead: 0 as const,
+        writesStartedByRead: 0 as const,
+        automaticDispatch: false as const,
+        semanticDecisionAuthority: false as const,
+        certificateAuthority: false as const,
+        externalWriteAuthority: false as const,
+        valueMovingAuthority: false as const,
+      }), { "cache-control": "no-store" });
+      return;
+    }
+    if (
+      request.method === "GET" &&
       url.pathname === "/api/v1/discovery-execution-capability"
     ) {
       try {

--- a/packages/control-plane/test/server.test.ts
+++ b/packages/control-plane/test/server.test.ts
@@ -565,6 +565,51 @@ describe("control-plane HTTP surface", () => {
     });
   });
 
+  it("serves a bounded external-Agent routing workspace", async () => {
+    const { baseUrl } = await listenControlPlane();
+    const response = await fetch(`${baseUrl}/api/v1/agent-workspace/routing`);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    const text = await response.text();
+    expect(Buffer.byteLength(text)).toBeLessThan(32_000);
+    const workspace = JSON.parse(text) as {
+      attention: { projectionIdentity: string };
+      targets: { allocationProjectionIdentity: string };
+    };
+    expect(workspace).toMatchObject({
+      schemaVersion: "pmh.agent-operator-workspace.v1",
+      execution: {
+        schemaVersion: "pmh.agent-execution-registry.v1",
+        credentialSecretTextRetained: false,
+      },
+      attention: {
+        schemaVersion: "pmh.research-attention-allocation.v1",
+        nextWork: [],
+        nextWorkTruncated: false,
+      },
+      targets: {
+        schemaVersion: "pmh.research-action-target-projection.v1",
+        nextTargets: [],
+        nextTargetsTruncated: false,
+      },
+      relationCampaign: {
+        schemaVersion: "pmh.relation-discovery-campaign-preview.v1",
+      },
+      discoveryCycle: { schemaVersion: "pmh.discovery-cycle.v1" },
+      providerRequestsStartedByRead: 0,
+      modelInvocationsStartedByRead: 0,
+      writesStartedByRead: 0,
+      automaticDispatch: false,
+      semanticDecisionAuthority: false,
+      certificateAuthority: false,
+      externalWriteAuthority: false,
+      valueMovingAuthority: false,
+    });
+    expect(workspace.targets.allocationProjectionIdentity).toBe(
+      workspace.attention.projectionIdentity,
+    );
+  });
+
   it("allows incremented loopback Studio origins without reflecting remote origins", async () => {
     const baseUrl = await listen();
 

--- a/plans/external-agent-operator-surface.md
+++ b/plans/external-agent-operator-surface.md
@@ -1,0 +1,73 @@
+# External Agent operator surface
+
+## Product proposition
+
+Auto Prediction has two AI layers. Internal Agents perform bounded research
+inside the control plane. External Agents and humans operate the product from
+outside it. Studio is the human observability surface; the versioned CLI and
+local HTTP control plane are the machine surface. Neither layer should require
+an Agent to infer UI labels, scrape rendered text, or reverse-engineer server
+routes before it can decide what to do next.
+
+## Observed gap
+
+The 2026-08-20 external-operator audit found that the released `pmh` CLI only
+read static venue manifests. It advertised a stale Node 24 runtime target and
+did not expose the existing startup-readiness or Agent-workspace projections.
+An external Agent could see that a CLI existed but could not use it to discover
+the running product, distinguish an offline control plane from startup work, or
+obtain bounded routing state.
+
+Grok Build topic session `61394efb-bf73-45af-aac2-a995c46d2585` was retained
+for the non-frontend audit. Its initial read expanded beyond 100k tokens without
+producing a diff; the continuation and subsequent compaction request also
+stalled. This is negative usability evidence, not implementation evidence:
+long-lived external operator sessions need proactive context budgets and Git
+state remains the acceptance boundary.
+
+## Selected direction
+
+Build the external surface as a progression of versioned, bounded affordances:
+
+1. **Discover and diagnose.** A zero-context Agent can ask the CLI for its exact
+   command catalog, inspect control-plane readiness, and read a compact Agent
+   routing workspace. Connection, timeout, HTTP, and schema failures retain
+   stable codes plus valid recovery commands.
+2. **Inspect exact work.** Add bounded commands for a selected task, campaign,
+   run, finding, or market evidence object. Compact listings must retain exact
+   identities needed for the next read rather than dumping whole projections.
+3. **Preview before mutation.** Every state-changing research command first
+   returns an exact preview and required authorization/idempotency fields.
+4. **Act and resume.** External Agents can create/activate/dispatch/pause
+   research campaigns, refresh anonymous catalogs, and resume failed work while
+   preserving the no-live-execution boundary.
+5. **Measure operator friction.** Retain command failures, retries, payload size,
+   time-to-first-valid-action, and context consumed per completed workflow.
+
+The CLI must remain a transport and projection client. It may compact and
+validate server state, but it must not reproduce semantic, economic,
+qualification, or verification verdict logic.
+
+## Current acceptance evidence
+
+- `pnpm --silent pmh` and `pnpm --silent pmh help` return the versioned command
+  catalog without a running control plane.
+- `pnpm --silent pmh ...` keeps stdout to one JSON envelope and incrementally
+  builds only the CLI dependency graph instead of the whole monorepo.
+- `pnpm pmh control status` reads `/api/v1/readiness` and distinguishes READY,
+  STARTING, FAILED, unreachable, timeout, malformed JSON, and HTTP failure.
+- `pnpm pmh agent workspace` validates the dedicated
+  `/api/v1/agent-workspace/routing` projection rather than downloading and
+  trimming the multi-megabyte Studio workspace.
+- Runtime qualification reduced that read from 5,696,671 bytes in 21.7 seconds
+  to 1,828 bytes in 42 milliseconds at the server; the hot CLI path completed
+  in about 0.9 seconds with one JSON envelope on stdout.
+- Every envelope still declares external writes, value movement, and live
+  execution as literal `false`.
+
+## Next implementation frontier
+
+The machine surface can discover work but cannot yet complete a useful research
+workflow. The next mainline slice should expose exact inspection for one
+selected target/task and a preview-only manual run command, then test the whole
+journey with a fresh external Agent session under an explicit context budget.


### PR DESCRIPTION
## Why

Auto Prediction has two AI layers: internal research Agents and external operator Agents. The released CLI only exposed static venue manifests, so a fresh external Agent had to infer UI labels or reverse-engineer large HTTP projections before it could choose a valid next action.

## What changed

- make `pmh` self-describing with a versioned command catalog
- add startup readiness and bounded Agent routing reads with stable diagnostics
- add dedicated `GET /api/v1/agent-workspace/routing` projection
- preserve exact action/task/target identities and literal no-write/no-value authority
- build only the CLI dependency graph and keep `--silent` stdout as one JSON envelope
- expose the machine quick start in README, operations, CLI docs, and Studio
- record the external operator direction and next preview-first workflow in the active plan

## Measured result

The existing human workspace read measured 5,696,671 bytes in 21.7 seconds. The dedicated routing projection measured 1,828 bytes in 42 ms server-side; the hot CLI path completed in about 0.9 seconds.

## Grok Build evidence

One retained topic session, `61394efb-bf73-45af-aac2-a995c46d2585`, was used for the non-frontend audit. It expanded beyond 100k tokens without producing a diff; continuation and compaction stalled. This is recorded as negative usability evidence. Git state and qualification results remain the acceptance boundary.

## Verification

- `pnpm check`
- `pnpm test`
- `pnpm studio:build`
- focused CLI: 11 tests
- control plane: 795 tests
- Studio: 30 tests
- desktop visual inspection of the System overview; no application console errors

## Authority

This remains inspection-only. Provider requests, model calls, writes, automatic dispatch, live execution, external writes, and value-moving authority remain false for these reads.