### PR TITLE
feat: add preview-first Agent workflow

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -23,9 +23,11 @@ Auto Prediction now treats the internal research Agent and the external
 operator Agent as separate first-class layers. The first mainline slice makes
 `pmh` self-describing, connects it to startup readiness and a bounded Agent
 workspace, and preserves stable recovery diagnostics without copying
-control-plane verdict logic. The next slice must turn one exact routed target
-into a previewable external-Agent workflow and measure time/context to the first
-valid action.
+control-plane verdict logic. Exact target/task inspection and a zero-effect
+manual-run preview now complete the read-to-preview journey. The next slice
+must bind an explicit authorization/idempotency reference to that preview,
+execute the research run, and expose bounded run inspection/resume while
+measuring time/context to the first retained outcome.
 
 The product brand is **Auto Prediction**, paired conceptually with Auto Quant.
 The rename is presentation-only for now: `pmh` CLI, package scopes, environment

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -22,6 +22,9 @@ pnpm --silent pmh help
 pnpm --silent pmh system status
 pnpm --silent pmh control status
 pnpm --silent pmh agent workspace
+pnpm --silent pmh agent target inspect <target-id>
+pnpm --silent pmh agent task inspect <task-id>
+pnpm --silent pmh agent task preview <task-id> <execution-profile-id>
 pnpm --silent pmh venue list
 pnpm --silent pmh venue inspect <venue-id>
 ```
@@ -33,6 +36,26 @@ attention actions and research targets, relation-campaign eligibility, and
 discovery-cycle state. It retains exact task/action/target identities needed
 for later commands and never downloads the multi-megabyte Studio workspace or
 copies semantic or economic verdict logic into the CLI.
+
+Continue by following the exact commands in `allowedNextActions`. A routable
+relation-discovery target supplies its bound task identity; task inspection
+supplies only the execution profiles compatible with that task kind. A
+`RUNNABLE` task then supplies a fully populated preview command. Historical or
+superseded tasks remain inspectable evidence but do not advertise an invalid
+preview action.
+
+`agent task preview` posts `mode: PREVIEW` to the first-party manual-run route.
+The response binds the requested task and profile identities and explicitly
+reports zero provider requests, model invocations, writes, and created runs.
+It grants no execution authority and deliberately does not advertise an
+execute command. This makes the current machine journey:
+
+```text
+agent workspace
+  -> agent target inspect <exact-target-id>
+  -> agent task inspect <exact-task-id>
+  -> agent task preview <exact-task-id> <exact-profile-id>
+```
 
 The default control plane is `http://127.0.0.1:4100`. Override it for another
 local or tunneled environment without changing command output:
@@ -54,7 +77,7 @@ Agents should follow that field rather than guessing a route.
 
 Unknown commands and venue identities fail closed with a non-zero process exit code and a JSON diagnostic. The present CLI cannot write external state or move value; both effects are literal `false` in every response.
 
-Exact target/task inspection, previewable manual runs, campaign control,
+Authorized manual execution, exact run inspection/resume, campaign control,
 catalog refresh, claim/link inspection, opportunity verification,
 deterministic replay, shadow execution, and Core projections remain planned CLI
 surfaces. Human-readable Studio views and compact CLI views consume

--- a/packages/cli/src/control-plane-client.ts
+++ b/packages/cli/src/control-plane-client.ts
@@ -50,6 +50,8 @@ export async function requestControlPlaneJson(
   path: `/${string}`,
   options: ControlPlaneClientOptions & Readonly<{
     acceptedStatuses?: readonly number[];
+    method?: "GET" | "POST";
+    body?: unknown;
   }> = {},
 ): Promise<Readonly<{ baseUrl: string; status: number; value: unknown }>> {
   const baseUrl = normalizedBaseUrl(
@@ -64,12 +66,22 @@ export async function requestControlPlaneJson(
     );
   }
 
+  const method = options.method ?? "GET";
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
   let response: Response;
   try {
     response = await (options.fetchImpl ?? fetch)(`${baseUrl}${path}`, {
-      headers: { accept: "application/json" },
+      method,
+      headers: method === "POST"
+        ? Object.freeze({
+            accept: "application/json",
+            "content-type": "application/json",
+          })
+        : Object.freeze({ accept: "application/json" }),
+      ...(method === "POST"
+        ? { body: JSON.stringify(options.body ?? {}) }
+        : {}),
       signal: controller.signal,
     });
   } catch (error) {

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -11,6 +11,9 @@ export const SUPPORTED_COMMANDS = Object.freeze([
   "system status",
   "control status",
   "agent workspace",
+  "agent target inspect <target-id>",
+  "agent task inspect <task-id>",
+  "agent task preview <task-id> <execution-profile-id>",
   "venue list",
   "venue inspect <venue-id>",
 ] as const);
@@ -38,6 +41,24 @@ const COMMAND_CATALOG = Object.freeze([
     command: "agent workspace",
     kind: "CONTROL_PLANE_READ",
     description: "Read a compact routing view of Agent work and execution state.",
+    requiresControlPlane: true,
+  }),
+  Object.freeze({
+    command: "agent target inspect <target-id>",
+    kind: "CONTROL_PLANE_READ",
+    description: "Inspect one research-action target by exact target identity.",
+    requiresControlPlane: true,
+  }),
+  Object.freeze({
+    command: "agent task inspect <task-id>",
+    kind: "CONTROL_PLANE_READ",
+    description: "Inspect one Agent task, its readiness, and previewable profiles.",
+    requiresControlPlane: true,
+  }),
+  Object.freeze({
+    command: "agent task preview <task-id> <execution-profile-id>",
+    kind: "CONTROL_PLANE_PREVIEW",
+    description: "Preview a manual Agent run without creating a run or calling a model.",
     requiresControlPlane: true,
   }),
   Object.freeze({
@@ -70,13 +91,37 @@ function numberValue(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
-function malformedControlPlaneEnvelope(
+function hashValue(value: string): boolean {
+  return /^sha256:[0-9a-f]{64}$/u.test(value);
+}
+
+function invalidIdentityEnvelope(
   command: string,
-  path: string,
+  args: readonly string[],
+  label: string,
 ): CliEnvelope {
   return createCliEnvelope({
     command,
-    arguments: [],
+    arguments: args,
+    state: null,
+    diagnostics: [{
+      severity: "ERROR",
+      code: "CLI_ARGUMENT_INVALID",
+      message: `${label} must be an exact sha256 identity.`,
+    }],
+    allowedNextActions: ["agent workspace", "help"],
+    ok: false,
+  });
+}
+
+function malformedControlPlaneEnvelope(
+  command: string,
+  path: string,
+  args: readonly string[] = [],
+): CliEnvelope {
+  return createCliEnvelope({
+    command,
+    arguments: args,
     state: null,
     diagnostics: [{
       severity: "ERROR",
@@ -91,6 +136,7 @@ function malformedControlPlaneEnvelope(
 function controlPlaneFailure(
   command: string,
   error: unknown,
+  args: readonly string[] = [],
 ): CliEnvelope {
   const diagnostic = error instanceof ControlPlaneRequestError
     ? error
@@ -100,7 +146,7 @@ function controlPlaneFailure(
     );
   return createCliEnvelope({
     command,
-    arguments: [],
+    arguments: args,
     state: null,
     diagnostics: [{
       severity: "ERROR",
@@ -110,6 +156,155 @@ function controlPlaneFailure(
     allowedNextActions: ["control status", "help"],
     ok: false,
   });
+}
+
+function hasLiteralFalseAuthority(value: JsonObject, keys: readonly string[]): boolean {
+  return keys.every((key) => value[key] === false);
+}
+
+function hasZeroOperatorReadEffects(value: JsonObject): boolean {
+  return value.providerRequestsStartedByRead === 0 &&
+    value.modelInvocationsStartedByRead === 0 &&
+    value.fetchesStartedByRead === 0 &&
+    value.writesStartedByRead === 0 &&
+    value.runsCreatedByRead === 0 &&
+    value.automaticDispatch === false &&
+    hasLiteralFalseAuthority(value, [
+      "semanticDecisionAuthority",
+      "certificateAuthority",
+      "executionAuthority",
+      "externalWriteAuthority",
+      "valueMovingAuthority",
+    ]);
+}
+
+function validateAgentOperatorTarget(value: unknown, targetId: string) {
+  const document = objectValue(value);
+  const target = objectValue(document?.target);
+  const allocationAction = document?.allocationAction === null
+    ? null
+    : objectValue(document?.allocationAction);
+  const manualOperation = objectValue(target?.manualOperation);
+  if (
+    document?.schemaVersion !== "pmh.agent-operator-target.v1" ||
+    target?.schemaVersion !== "pmh.research-action-target.v1" ||
+    target.targetId !== targetId ||
+    manualOperation === null ||
+    typeof manualOperation.available !== "boolean" ||
+    typeof manualOperation.kind !== "string" ||
+    (manualOperation.kind === "RELATION_DISCOVERY_TASK" && (
+      manualOperation.available !== true ||
+      typeof manualOperation.targetId !== "string" ||
+      manualOperation.targetId !== target.sourceTaskId
+    )) ||
+    !hasZeroOperatorReadEffects(document) ||
+    !hasLiteralFalseAuthority(target, [
+      "automaticDispatch",
+      "modelInvocationAuthority",
+      "providerRequestAuthority",
+      "fetchAuthority",
+      "campaignAuthority",
+      "semanticDecisionAuthority",
+      "certificateAuthority",
+      "executionAuthority",
+      "externalWriteAuthority",
+      "valueMovingAuthority",
+    ]) ||
+    allocationAction === null ||
+    (
+      allocationAction.schemaVersion !== "pmh.research-attention-allocation-action.v2" ||
+      allocationAction.actionId !== target.allocationActionId ||
+      !hasLiteralFalseAuthority(allocationAction, [
+        "modelInvocationAuthority",
+        "campaignAuthority",
+        "executionAuthority",
+        "externalWriteAuthority",
+        "valueMovingAuthority",
+      ])
+    )
+  ) return null;
+  return Object.freeze({ document, target, allocationAction, manualOperation });
+}
+
+function validateAgentOperatorTask(value: unknown, taskId: string) {
+  const document = objectValue(value);
+  const task = objectValue(document?.task);
+  const readiness = objectValue(document?.readiness);
+  const authority = objectValue(task?.authority);
+  const profiles = Array.isArray(document?.compatibleExecutionProfiles)
+    ? document.compatibleExecutionProfiles
+    : null;
+  const runs = Array.isArray(document?.runs) ? document.runs : null;
+  if (
+    document?.schemaVersion !== "pmh.agent-operator-task.v1" ||
+    task?.schemaVersion !== "pmh.agent-task.v1" ||
+    task.taskId !== taskId ||
+    readiness === null ||
+    !["RUNNABLE", "SUPERSEDED_INPUT", "HISTORICAL_ONLY"].includes(
+      String(readiness.status),
+    ) ||
+    authority?.modelInvocations !== false ||
+    authority.externalWrites !== false ||
+    authority.semanticDecision !== false ||
+    authority.certificatePublication !== false ||
+    authority.valueMovingActions !== false ||
+    !hasZeroOperatorReadEffects(document) ||
+    profiles === null ||
+    runs === null ||
+    !profiles.every((item) => {
+      const profile = objectValue(item);
+      return profile !== null &&
+        typeof profile.executionProfileId === "string" &&
+        profile.automaticDispatch === false;
+    })
+  ) return null;
+  return Object.freeze({
+    document,
+    task,
+    readiness,
+    compatibleExecutionProfiles: profiles.flatMap((item) => {
+      const profile = objectValue(item);
+      return profile === null || typeof profile.executionProfileId !== "string"
+        ? []
+        : [profile];
+    }),
+  });
+}
+
+function validateManualRunPreview(
+  value: unknown,
+  taskId: string,
+  executionProfileId: string,
+) {
+  const document = objectValue(value);
+  const preview = objectValue(document?.preview);
+  const task = objectValue(preview?.task);
+  const executionProfile = objectValue(preview?.executionProfile);
+  const authority = objectValue(task?.authority);
+  if (
+    document?.ok !== true ||
+    document.run !== undefined ||
+    preview === null ||
+    task?.schemaVersion !== "pmh.agent-task.v1" ||
+    task.taskId !== taskId ||
+    executionProfile?.schemaVersion !== "pmh.execution-profile.v1" ||
+    executionProfile.executionProfileId !== executionProfileId ||
+    preview.providerRequestsStarted !== 0 ||
+    document.providerRequestsStarted !== 0 ||
+    document.modelInvocationsStarted !== 0 ||
+    document.writesStarted !== 0 ||
+    document.runsCreated !== 0 ||
+    document.executionAuthority !== false ||
+    document.externalWriteAuthority !== false ||
+    document.valueMovingAuthority !== false ||
+    authority?.modelInvocations !== false ||
+    authority.externalWrites !== false ||
+    authority.semanticDecision !== false ||
+    authority.certificatePublication !== false ||
+    authority.valueMovingActions !== false ||
+    document.mode !== "PREVIEW"
+  ) return null;
+  return Object.freeze({ document, preview, task, executionProfile });
 }
 
 function validateAgentOperatorWorkspace(value: unknown) {
@@ -310,6 +505,164 @@ export async function runCli(
       });
     } catch (error) {
       return controlPlaneFailure("agent.workspace", error);
+    }
+  }
+
+  if (
+    namespace === "agent" &&
+    action === "target" &&
+    venueId === "inspect" &&
+    extra.length === 1 &&
+    extra[0] !== undefined
+  ) {
+    const targetId = extra[0];
+    if (!hashValue(targetId)) {
+      return invalidIdentityEnvelope(
+        "agent.target.inspect",
+        [targetId],
+        "target-id",
+      );
+    }
+    const path = `/api/v1/agent-operator/targets/${targetId}` as `/${string}`;
+    try {
+      const result = await requestControlPlaneJson(path, options);
+      const inspected = validateAgentOperatorTarget(result.value, targetId);
+      if (inspected === null) {
+        return malformedControlPlaneEnvelope("agent.target.inspect", path, [targetId]);
+      }
+      const linkedTaskId = inspected.manualOperation?.kind === "RELATION_DISCOVERY_TASK"
+          && inspected.manualOperation.available === true
+        ? stringValue(inspected.manualOperation.targetId)
+        : null;
+      return createCliEnvelope({
+        command: "agent.target.inspect",
+        arguments: [targetId],
+        state: Object.freeze({
+          ...inspected.document,
+          controlPlaneUrl: result.baseUrl,
+        }),
+        allowedNextActions: Object.freeze([
+          ...(linkedTaskId === null
+            ? []
+            : [`agent task inspect ${linkedTaskId}`]),
+          "agent workspace",
+          "help",
+        ]),
+        ok: true,
+      });
+    } catch (error) {
+      return controlPlaneFailure("agent.target.inspect", error, [targetId]);
+    }
+  }
+
+  if (
+    namespace === "agent" &&
+    action === "task" &&
+    venueId === "inspect" &&
+    extra.length === 1 &&
+    extra[0] !== undefined
+  ) {
+    const taskId = extra[0];
+    if (!hashValue(taskId)) {
+      return invalidIdentityEnvelope("agent.task.inspect", [taskId], "task-id");
+    }
+    const path = `/api/v1/agent-operator/tasks/${taskId}` as `/${string}`;
+    try {
+      const result = await requestControlPlaneJson(path, options);
+      const inspected = validateAgentOperatorTask(result.value, taskId);
+      if (inspected === null) {
+        return malformedControlPlaneEnvelope("agent.task.inspect", path, [taskId]);
+      }
+      const previewActions = inspected.readiness.status === "RUNNABLE"
+        ? [...new Set(inspected.compatibleExecutionProfiles.map((profile) =>
+            `agent task preview ${taskId} ${String(profile.executionProfileId)}`
+          ))]
+        : [];
+      return createCliEnvelope({
+        command: "agent.task.inspect",
+        arguments: [taskId],
+        state: Object.freeze({
+          ...inspected.document,
+          controlPlaneUrl: result.baseUrl,
+        }),
+        allowedNextActions: Object.freeze([
+          ...previewActions,
+          "agent workspace",
+          "help",
+        ]),
+        ok: true,
+      });
+    } catch (error) {
+      return controlPlaneFailure("agent.task.inspect", error, [taskId]);
+    }
+  }
+
+  if (
+    namespace === "agent" &&
+    action === "task" &&
+    venueId === "preview" &&
+    extra.length === 2 &&
+    extra[0] !== undefined &&
+    extra[1] !== undefined
+  ) {
+    const taskId = extra[0];
+    const executionProfileId = extra[1];
+    if (!hashValue(taskId) || !hashValue(executionProfileId)) {
+      return invalidIdentityEnvelope(
+        "agent.task.preview",
+        [taskId, executionProfileId],
+        !hashValue(taskId) ? "task-id" : "execution-profile-id",
+      );
+    }
+    const path = `/api/v1/agent-tasks/${taskId}/runs` as `/${string}`;
+    try {
+      const result = await requestControlPlaneJson(path, {
+        ...options,
+        method: "POST",
+        body: Object.freeze({
+          mode: "PREVIEW",
+          executionProfileId,
+        }),
+      });
+      const previewed = validateManualRunPreview(
+        result.value,
+        taskId,
+        executionProfileId,
+      );
+      if (previewed === null) {
+        return malformedControlPlaneEnvelope("agent.task.preview", path, [
+          taskId,
+          executionProfileId,
+        ]);
+      }
+      return createCliEnvelope({
+        command: "agent.task.preview",
+        arguments: [taskId, executionProfileId],
+        state: Object.freeze({
+          mode: "PREVIEW" as const,
+          ok: true as const,
+          controlPlaneUrl: result.baseUrl,
+          preview: previewed.preview,
+          providerRequestsStarted: 0 as const,
+          modelInvocationsStarted: 0 as const,
+          writesStarted: 0 as const,
+          runsCreated: 0 as const,
+          executionAuthority: false as const,
+          externalWriteAuthority: false as const,
+          valueMovingAuthority: false as const,
+        }),
+        allowedNextActions: Object.freeze([
+          `agent task inspect ${taskId}`,
+          "agent workspace",
+          "help",
+        ]),
+        ok: true,
+      });
+    } catch (error) {
+      return controlPlaneFailure("agent.task.preview", error, [
+        taskId,
+        executionProfileId,
+      ]);
     }
   }
 

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -1,4 +1,4 @@
-import { createServer, type Server } from "node:http";
+import { createServer, type IncomingMessage, type Server } from "node:http";
 import { afterEach, describe, expect, it } from "vitest";
 import { CLI_SCHEMA_VERSION, runCli } from "../src/index.js";
 
@@ -32,6 +32,133 @@ function json(
   response.end(JSON.stringify(value));
 }
 
+async function readJsonBody(request: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  return JSON.parse(Buffer.concat(chunks).toString("utf8")) as unknown;
+}
+
+const TARGET_ID = `sha256:${"1".repeat(64)}`;
+const TASK_ID = `sha256:${"2".repeat(64)}`;
+const PROFILE_ID = `sha256:${"3".repeat(64)}`;
+const OTHER_ID = `sha256:${"a".repeat(64)}`;
+
+const OPERATOR_READ_EFFECTS = Object.freeze({
+  providerRequestsStartedByRead: 0,
+  modelInvocationsStartedByRead: 0,
+  fetchesStartedByRead: 0,
+  writesStartedByRead: 0,
+  runsCreatedByRead: 0,
+  automaticDispatch: false,
+  semanticDecisionAuthority: false,
+  certificateAuthority: false,
+  executionAuthority: false,
+  externalWriteAuthority: false,
+  valueMovingAuthority: false,
+});
+
+const TASK_AUTHORITY = Object.freeze({
+  modelInvocations: false,
+  externalWrites: false,
+  semanticDecision: false,
+  certificatePublication: false,
+  valueMovingActions: false,
+});
+
+function operatorTarget(targetId: string) {
+  return {
+    schemaVersion: "pmh.agent-operator-target.v1",
+    target: {
+      schemaVersion: "pmh.research-action-target.v1",
+      targetId,
+      allocationActionId: `sha256:${"4".repeat(64)}`,
+      allocationActionKind: "EXPLORE_NEW_FAMILY",
+      sourceTaskId: TASK_ID,
+      state: "READY_RELATION_DISCOVERY",
+      diagnostic: "ready",
+      automaticDispatch: false,
+      modelInvocationAuthority: false,
+      providerRequestAuthority: false,
+      fetchAuthority: false,
+      campaignAuthority: false,
+      semanticDecisionAuthority: false,
+      certificateAuthority: false,
+      executionAuthority: false,
+      externalWriteAuthority: false,
+      valueMovingAuthority: false,
+      manualOperation: {
+        available: true,
+        kind: "RELATION_DISCOVERY_TASK",
+        targetId: TASK_ID,
+      },
+    },
+    allocationAction: {
+      schemaVersion: "pmh.research-attention-allocation-action.v2",
+      actionId: `sha256:${"4".repeat(64)}`,
+      kind: "EXPLORE_NEW_FAMILY",
+      modelInvocationAuthority: false,
+      campaignAuthority: false,
+      executionAuthority: false,
+      externalWriteAuthority: false,
+      valueMovingAuthority: false,
+    },
+    ...OPERATOR_READ_EFFECTS,
+  };
+}
+
+function operatorTask(taskId: string, profileId = PROFILE_ID) {
+  return {
+    schemaVersion: "pmh.agent-operator-task.v1",
+    task: {
+      schemaVersion: "pmh.agent-task.v1",
+      taskId,
+      kind: "RELATION_DISCOVERY",
+      authority: TASK_AUTHORITY,
+    },
+    readiness: { status: "RUNNABLE", diagnostic: "current", successorTaskId: null },
+    compatibleExecutionProfiles: [{
+      executionProfileId: profileId,
+      profileKey: "relation-discovery-codex-app-server",
+      automaticDispatch: false,
+    }],
+    runs: [],
+    runsTruncated: false,
+    ...OPERATOR_READ_EFFECTS,
+  };
+}
+
+function previewDocument(taskId: string, executionProfileId: string) {
+  return {
+    ok: true,
+    mode: "PREVIEW",
+    preview: {
+      task: {
+        schemaVersion: "pmh.agent-task.v1",
+        taskId,
+        kind: "RELATION_DISCOVERY",
+        authority: TASK_AUTHORITY,
+      },
+      executionProfile: {
+        schemaVersion: "pmh.execution-profile.v1",
+        executionProfileId,
+        profileKey: "relation-discovery-codex-app-server",
+      },
+      nextRunOrdinal: 1,
+      maximumModelInvocations: 12,
+      providerRequestsStarted: 0,
+    },
+    providerRequestsStarted: 0,
+    modelInvocationsStarted: 0,
+    writesStarted: 0,
+    runsCreated: 0,
+    executionAuthority: false,
+    externalWriteAuthority: false,
+    valueMovingAuthority: false,
+  };
+}
+
 describe("versioned CLI envelope", () => {
   it("discovers the exact command surface without a running control plane", async () => {
     const result = await runCli([]);
@@ -43,6 +170,11 @@ describe("versioned CLI envelope", () => {
       interface: "pmh.cli.v1",
     });
     expect(result.allowedNextActions).toContain("agent workspace");
+    expect(result.allowedNextActions).toContain("agent target inspect <target-id>");
+    expect(result.allowedNextActions).toContain("agent task inspect <task-id>");
+    expect(result.allowedNextActions).toContain(
+      "agent task preview <task-id> <execution-profile-id>",
+    );
   });
 
   it("reports the system's Node 22 baseline and live-disabled boundary", async () => {
@@ -245,6 +377,243 @@ describe("versioned CLI envelope", () => {
     expect(result.diagnostics[0]?.code).toBe(
       "CONTROL_PLANE_MALFORMED_RESPONSE",
     );
+  });
+
+  it("inspects one research-action target and fills the linked task command", async () => {
+    const baseUrl = await serve((request, response) => {
+      expect(request.method).toBe("GET");
+      expect(request.url).toBe(`/api/v1/agent-operator/targets/${TARGET_ID}`);
+      json(response, operatorTarget(TARGET_ID));
+    });
+    const result = await runCli(
+      ["agent", "target", "inspect", TARGET_ID],
+      { baseUrl },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.identity).toEqual({
+      command: "agent.target.inspect",
+      arguments: [TARGET_ID],
+    });
+    expect(result.state).toMatchObject({
+      schemaVersion: "pmh.agent-operator-target.v1",
+      target: { targetId: TARGET_ID },
+      providerRequestsStartedByRead: 0,
+      executionAuthority: false,
+      valueMovingAuthority: false,
+    });
+    expect(result.allowedNextActions).toEqual([
+      `agent task inspect ${TASK_ID}`,
+      "agent workspace",
+      "help",
+    ]);
+    expect(result.effects).toEqual({
+      externalWrites: false,
+      valueMovingActions: false,
+      liveExecutionEnabled: false,
+    });
+  });
+
+  it("rejects a target inspect whose identity does not match the request", async () => {
+    const baseUrl = await serve((_request, response) =>
+      json(response, operatorTarget(OTHER_ID))
+    );
+    const result = await runCli(
+      ["agent", "target", "inspect", TARGET_ID],
+      { baseUrl },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0]?.code).toBe("CONTROL_PLANE_MALFORMED_RESPONSE");
+  });
+
+  it("rejects malformed exact identities before contacting the control plane", async () => {
+    let requested = false;
+    const result = await runCli(
+      ["agent", "target", "inspect", "../readiness"],
+      {
+        fetchImpl: async () => {
+          requested = true;
+          throw new Error("must not request");
+        },
+      },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0]).toMatchObject({
+      code: "CLI_ARGUMENT_INVALID",
+      message: "target-id must be an exact sha256 identity.",
+    });
+    expect(requested).toBe(false);
+  });
+
+  it("retains a target 404 as a stable HTTP diagnostic", async () => {
+    const baseUrl = await serve((request, response) => {
+      expect(request.url).toBe(`/api/v1/agent-operator/targets/${TARGET_ID}`);
+      json(response, {
+        ok: false,
+        diagnostic: `research-action target ${TARGET_ID} was not found`,
+      }, 404);
+    });
+    const result = await runCli(
+      ["agent", "target", "inspect", TARGET_ID],
+      { baseUrl },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0]).toMatchObject({
+      code: "CONTROL_PLANE_HTTP_ERROR",
+      message: expect.stringContaining(
+        `research-action target ${TARGET_ID} was not found`,
+      ),
+    });
+  });
+
+  it("inspects one Agent task and fills exact preview commands", async () => {
+    const baseUrl = await serve((request, response) => {
+      expect(request.method).toBe("GET");
+      expect(request.url).toBe(`/api/v1/agent-operator/tasks/${TASK_ID}`);
+      json(response, operatorTask(TASK_ID));
+    });
+    const result = await runCli(
+      ["agent", "task", "inspect", TASK_ID],
+      { baseUrl },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.identity.command).toBe("agent.task.inspect");
+    expect(result.state).toMatchObject({
+      schemaVersion: "pmh.agent-operator-task.v1",
+      task: { taskId: TASK_ID },
+      compatibleExecutionProfiles: [{
+        executionProfileId: PROFILE_ID,
+        automaticDispatch: false,
+      }],
+      providerRequestsStartedByRead: 0,
+      modelInvocationsStartedByRead: 0,
+      writesStartedByRead: 0,
+    });
+    expect(result.allowedNextActions).toEqual([
+      `agent task preview ${TASK_ID} ${PROFILE_ID}`,
+      "agent workspace",
+      "help",
+    ]);
+  });
+
+  it("does not advertise preview for a non-runnable Agent task", async () => {
+    const baseUrl = await serve((_request, response) => json(response, {
+      ...operatorTask(TASK_ID),
+      readiness: {
+        status: "HISTORICAL_ONLY",
+        diagnostic: "task is retained evidence only",
+        successorTaskId: null,
+      },
+    }));
+    const result = await runCli(
+      ["agent", "task", "inspect", TASK_ID],
+      { baseUrl },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.allowedNextActions).toEqual(["agent workspace", "help"]);
+  });
+
+  it("rejects a task inspect whose identity does not match the request", async () => {
+    const baseUrl = await serve((_request, response) =>
+      json(response, operatorTask(OTHER_ID))
+    );
+    const result = await runCli(
+      ["agent", "task", "inspect", TASK_ID],
+      { baseUrl },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0]?.code).toBe("CONTROL_PLANE_MALFORMED_RESPONSE");
+  });
+
+  it("retains a task 404 as a stable HTTP diagnostic", async () => {
+    const baseUrl = await serve((_request, response) => json(response, {
+      ok: false,
+      diagnostic: `Agent task ${TASK_ID} was not found`,
+    }, 404));
+    const result = await runCli(
+      ["agent", "task", "inspect", TASK_ID],
+      { baseUrl },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0]).toMatchObject({
+      code: "CONTROL_PLANE_HTTP_ERROR",
+      message: expect.stringContaining(`Agent task ${TASK_ID} was not found`),
+    });
+  });
+
+  it("previews a manual run without execute authority or a created run", async () => {
+    const baseUrl = await serve(async (request, response) => {
+      expect(request.method).toBe("POST");
+      expect(request.url).toBe(`/api/v1/agent-tasks/${TASK_ID}/runs`);
+      expect(await readJsonBody(request)).toEqual({
+        mode: "PREVIEW",
+        executionProfileId: PROFILE_ID,
+      });
+      json(response, previewDocument(TASK_ID, PROFILE_ID));
+    });
+    const result = await runCli(
+      ["agent", "task", "preview", TASK_ID, PROFILE_ID],
+      { baseUrl },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.identity).toEqual({
+      command: "agent.task.preview",
+      arguments: [TASK_ID, PROFILE_ID],
+    });
+    expect(result.state).toMatchObject({
+      mode: "PREVIEW",
+      preview: {
+        task: { taskId: TASK_ID },
+        executionProfile: { executionProfileId: PROFILE_ID },
+        providerRequestsStarted: 0,
+      },
+      providerRequestsStarted: 0,
+      modelInvocationsStarted: 0,
+      writesStarted: 0,
+      runsCreated: 0,
+      executionAuthority: false,
+      externalWriteAuthority: false,
+      valueMovingAuthority: false,
+    });
+    expect(result.state).not.toHaveProperty("run");
+    expect(result.allowedNextActions).toEqual([
+      `agent task inspect ${TASK_ID}`,
+      "agent workspace",
+      "help",
+    ]);
+    expect(result.allowedNextActions.join(" ")).not.toMatch(/execute/i);
+    expect(result.effects.liveExecutionEnabled).toBe(false);
+  });
+
+  it("rejects a preview whose returned identities do not match the request", async () => {
+    const baseUrl = await serve(async (request, response) => {
+      await readJsonBody(request);
+      json(response, previewDocument(OTHER_ID, PROFILE_ID));
+    });
+    const result = await runCli(
+      ["agent", "task", "preview", TASK_ID, PROFILE_ID],
+      { baseUrl },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0]?.code).toBe("CONTROL_PLANE_MALFORMED_RESPONSE");
+  });
+
+  it("retains a preview 404 as a stable HTTP diagnostic", async () => {
+    const baseUrl = await serve(async (request, response) => {
+      expect(await readJsonBody(request)).toMatchObject({ mode: "PREVIEW" });
+      json(response, {
+        ok: false,
+        diagnostic: "Agent task is unavailable",
+      }, 404);
+    });
+    const result = await runCli(
+      ["agent", "task", "preview", TASK_ID, PROFILE_ID],
+      { baseUrl },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0]).toMatchObject({
+      code: "CONTROL_PLANE_HTTP_ERROR",
+      message: expect.stringContaining("Agent task is unavailable"),
+    });
   });
 
   it("inspects validated venue capability evidence", async () => {

--- a/packages/control-plane/src/server.ts
+++ b/packages/control-plane/src/server.ts
@@ -6739,6 +6739,125 @@ export function createControlPlane(options?: {
       }), { "cache-control": "no-store" });
       return;
     }
+    const operatorTargetMatch = url.pathname.match(
+      /^\/api\/v1\/agent-operator\/targets\/(sha256:[0-9a-f]{64})$/u,
+    );
+    if (request.method === "GET" && operatorTargetMatch !== null) {
+      await ready;
+      const research = currentResearchActionState();
+      const targetId = operatorTargetMatch[1] as Hash;
+      const target = research.targets.targets.find((item) => item.targetId === targetId);
+      const operatorReadEffects = Object.freeze({
+        providerRequestsStartedByRead: 0 as const,
+        modelInvocationsStartedByRead: 0 as const,
+        fetchesStartedByRead: 0 as const,
+        writesStartedByRead: 0 as const,
+        runsCreatedByRead: 0 as const,
+        automaticDispatch: false as const,
+        semanticDecisionAuthority: false as const,
+        certificateAuthority: false as const,
+        executionAuthority: false as const,
+        externalWriteAuthority: false as const,
+        valueMovingAuthority: false as const,
+      });
+      if (target === undefined) {
+        writeJson(response, 404, Object.freeze({
+          ok: false as const,
+          diagnostic: `research-action target ${targetId} was not found`,
+          ...operatorReadEffects,
+        }), { "cache-control": "no-store" });
+        return;
+      }
+      writeJson(response, 200, Object.freeze({
+        schemaVersion: "pmh.agent-operator-target.v1" as const,
+        target,
+        allocationAction: research.allocation.portfolio.find((item) =>
+          item.actionId === target.allocationActionId
+        ) ?? null,
+        ...operatorReadEffects,
+      }), { "cache-control": "no-store" });
+      return;
+    }
+    const operatorTaskMatch = url.pathname.match(
+      /^\/api\/v1\/agent-operator\/tasks\/(sha256:[0-9a-f]{64})$/u,
+    );
+    if (request.method === "GET" && operatorTaskMatch !== null) {
+      await ready;
+      const snapshot = agentExecutionRegistry.snapshot();
+      const taskId = operatorTaskMatch[1] as Hash;
+      const task = snapshot.tasks.find((item) => item.taskId === taskId);
+      const operatorReadEffects = Object.freeze({
+        providerRequestsStartedByRead: 0 as const,
+        modelInvocationsStartedByRead: 0 as const,
+        fetchesStartedByRead: 0 as const,
+        writesStartedByRead: 0 as const,
+        runsCreatedByRead: 0 as const,
+        automaticDispatch: false as const,
+        semanticDecisionAuthority: false as const,
+        certificateAuthority: false as const,
+        executionAuthority: false as const,
+        externalWriteAuthority: false as const,
+        valueMovingAuthority: false as const,
+      });
+      if (task === undefined) {
+        writeJson(response, 404, Object.freeze({
+          ok: false as const,
+          diagnostic: `Agent task ${taskId} was not found`,
+          ...operatorReadEffects,
+        }), { "cache-control": "no-store" });
+        return;
+      }
+      const latestRoutesByKey = new Map<string, (typeof snapshot.workloadRoutes)[number]>();
+      for (const route of snapshot.workloadRoutes) {
+        if (route.taskKind !== task.kind) continue;
+        const current = latestRoutesByKey.get(route.routeKey);
+        if (current === undefined || route.revision > current.revision) {
+          latestRoutesByKey.set(route.routeKey, route);
+        }
+      }
+      const compatibleExecutionProfiles = Object.freeze([...latestRoutesByKey.values()]
+        .sort((left, right) => left.routeKey.localeCompare(right.routeKey) ||
+          left.workloadRouteId.localeCompare(right.workloadRouteId))
+        .flatMap((route) => {
+          const profile = snapshot.executionProfiles.find((item) =>
+            item.executionProfileId === route.executionProfileId
+          );
+          return profile === undefined ? [] : [Object.freeze({
+            executionProfileId: profile.executionProfileId,
+            profileKey: profile.profileKey,
+            revision: profile.revision,
+            workloadRouteId: route.workloadRouteId,
+            routeKey: route.routeKey,
+            toolProtocol: profile.toolPolicy.protocol,
+            runBudget: profile.runBudget,
+            automaticDispatch: false as const,
+          })];
+        }));
+      const matchingRuns = snapshot.runs.filter((item) => item.taskId === taskId)
+        .sort((left, right) =>
+          right.createdAt.localeCompare(left.createdAt) ||
+          left.runId.localeCompare(right.runId)
+        );
+      const runSummaries = matchingRuns.slice(0, 12).map((run) => Object.freeze({
+        runId: run.runId,
+        status: run.status,
+        executionProfileId: run.executionProfileId,
+        runOrdinal: run.runOrdinal,
+        createdAt: run.createdAt,
+        completedAt: run.completedAt,
+        terminalDiagnostic: run.terminalDiagnostic,
+      }));
+      writeJson(response, 200, Object.freeze({
+        schemaVersion: "pmh.agent-operator-task.v1" as const,
+        task,
+        readiness: agentTaskReadiness(task),
+        compatibleExecutionProfiles,
+        runs: Object.freeze(runSummaries),
+        runsTruncated: matchingRuns.length > runSummaries.length,
+        ...operatorReadEffects,
+      }), { "cache-control": "no-store" });
+      return;
+    }
     if (
       request.method === "GET" &&
       url.pathname === "/api/v1/discovery-execution-capability"
@@ -8669,7 +8788,18 @@ export function createControlPlane(options?: {
           body.executionProfileId as Hash,
         );
         if (body.mode === "PREVIEW") {
-          writeJson(response, 200, { ok: true, preview });
+          writeJson(response, 200, {
+            ok: true,
+            mode: "PREVIEW" as const,
+            preview,
+            providerRequestsStarted: 0 as const,
+            modelInvocationsStarted: 0 as const,
+            writesStarted: 0 as const,
+            runsCreated: 0 as const,
+            executionAuthority: false as const,
+            externalWriteAuthority: false as const,
+            valueMovingAuthority: false as const,
+          });
         } else {
           const dispatched = agentCampaignDispatcher.dispatchManual(
             manualAgentRunMatch[1] as Hash,

--- a/packages/control-plane/test/agent-campaign-dispatcher.test.ts
+++ b/packages/control-plane/test/agent-campaign-dispatcher.test.ts
@@ -423,6 +423,11 @@ describe("Agent campaign dispatcher", () => {
       maximumModelInvocations: 8,
       providerRequestsStarted: 0,
     });
+    expect(item.registry.snapshot()).toMatchObject({
+      runs: [],
+      modelInvocations: [],
+      toolEffects: [],
+    });
     const dispatched = item.dispatcher.dispatchManual(
       work.taskId,
       profile.executionProfileId,

--- a/packages/control-plane/test/server.test.ts
+++ b/packages/control-plane/test/server.test.ts
@@ -7,6 +7,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { hashCanonical } from "@pmh/domain";
 import {
   AiRuntimeConfigurationDesk,
+  AgentCampaignDispatcher,
+  AgentCredentialBroker,
   AgentExecutionRegistry,
   activateAgentCampaign,
   AnonymousSimulationMaterializerDesk,
@@ -18,6 +20,7 @@ import {
   buildStudioProjectionSnapshot,
   buildAgentTask,
   buildAgentRun,
+  buildDefaultAgentRuntimePortfolio,
   buildMarketCorpusSnapshot,
   buildPausedAgentCampaign,
   buildWorldRelationEntityRoleAssertion,
@@ -608,6 +611,242 @@ describe("control-plane HTTP surface", () => {
     expect(workspace.targets.allocationProjectionIdentity).toBe(
       workspace.attention.projectionIdentity,
     );
+  });
+
+  it("binds one research-action target inspect and fails closed when missing", async () => {
+    const missingId = `sha256:${"0".repeat(64)}`;
+    const { baseUrl } = await listenControlPlane();
+    const missing = await fetch(`${baseUrl}/api/v1/agent-operator/targets/${missingId}`);
+    expect(missing.status).toBe(404);
+    expect(missing.headers.get("cache-control")).toBe("no-store");
+    const missingBody = await missing.json() as Record<string, unknown>;
+    expect(missingBody).toMatchObject({
+      ok: false,
+      diagnostic: `research-action target ${missingId} was not found`,
+      providerRequestsStartedByRead: 0,
+      modelInvocationsStartedByRead: 0,
+      fetchesStartedByRead: 0,
+      writesStartedByRead: 0,
+      runsCreatedByRead: 0,
+      automaticDispatch: false,
+      semanticDecisionAuthority: false,
+      certificateAuthority: false,
+      executionAuthority: false,
+      externalWriteAuthority: false,
+      valueMovingAuthority: false,
+    });
+    expect(missingBody).not.toHaveProperty("target");
+    expect(missingBody).not.toHaveProperty("execution");
+    expect(JSON.stringify(missingBody)).not.toMatch(/worldStateMechanisms|families|listings/);
+
+    const routing = await fetch(`${baseUrl}/api/v1/agent-workspace/routing`)
+      .then((response) => response.json()) as {
+        targets: { nextTargets: Array<{ targetId: string }> };
+      };
+    expect(routing.targets.nextTargets).toEqual([]);
+  });
+
+  it("binds one Agent task inspect to exact identity, readiness, and that task's runs", async () => {
+    const registry = new AgentExecutionRegistry();
+    const retained = buildAgentTask({
+      kind: "RULE_EVIDENCE_CLAIM",
+      protocol: "RULE_EVIDENCE_TASK_V1",
+      inputArtifacts: [],
+      taskPayload: { fixture: "operator-task-inspect" },
+      requestedEffectProtocol: "RULE_EVIDENCE_TOOLS_V1",
+      provenanceRef: "fixture:operator-task-inspect",
+      priority: 1,
+      createdAt: "2026-08-20T10:00:00.000Z",
+    });
+    const other = buildAgentTask({
+      kind: "RULE_EVIDENCE_CLAIM",
+      protocol: "RULE_EVIDENCE_TASK_V1",
+      inputArtifacts: [],
+      taskPayload: { fixture: "operator-task-other" },
+      requestedEffectProtocol: "RULE_EVIDENCE_TOOLS_V1",
+      provenanceRef: "fixture:operator-task-other",
+      priority: 2,
+      createdAt: "2026-08-20T10:01:00.000Z",
+    });
+    registry.saveBatch({ tasks: [retained, other] });
+    const { baseUrl } = await listenControlPlane({ agentExecutionRegistry: registry });
+    const profile = registry.snapshot().executionProfiles.find((item) =>
+      item.profileKey === "rule-evidence-codex-app-server"
+    )!;
+    const retainedRun = completeAgentRun(
+      buildAgentRun({
+        task: retained,
+        executionProfile: profile,
+        runOrdinal: 1,
+        authorization: {
+          kind: "MANUAL",
+          authorizationRef: "operator:inspect-fixture",
+          authorizedAt: "2026-08-20T10:02:00.000Z",
+        },
+        createdAt: "2026-08-20T10:02:00.000Z",
+      }),
+      "FAILED",
+      "2026-08-20T10:03:00.000Z",
+      "fixture diagnostic only",
+    );
+    const otherRun = completeAgentRun(
+      buildAgentRun({
+        task: other,
+        executionProfile: profile,
+        runOrdinal: 1,
+        authorization: {
+          kind: "MANUAL",
+          authorizationRef: "operator:inspect-other",
+          authorizedAt: "2026-08-20T10:04:00.000Z",
+        },
+        createdAt: "2026-08-20T10:04:00.000Z",
+      }),
+      "FAILED",
+      "2026-08-20T10:05:00.000Z",
+      "other task must not leak",
+    );
+    registry.saveBatch({ runs: [retainedRun, otherRun] });
+
+    const missingId = `sha256:${"a".repeat(64)}`;
+    const missing = await fetch(`${baseUrl}/api/v1/agent-operator/tasks/${missingId}`);
+    expect(missing.status).toBe(404);
+    await expect(missing.json()).resolves.toMatchObject({
+      ok: false,
+      diagnostic: `Agent task ${missingId} was not found`,
+      providerRequestsStartedByRead: 0,
+      modelInvocationsStartedByRead: 0,
+      writesStartedByRead: 0,
+      runsCreatedByRead: 0,
+      executionAuthority: false,
+      externalWriteAuthority: false,
+      valueMovingAuthority: false,
+    });
+
+    const response = await fetch(
+      `${baseUrl}/api/v1/agent-operator/tasks/${retained.taskId}`,
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    const text = await response.text();
+    expect(Buffer.byteLength(text)).toBeLessThan(16_000);
+    const body = JSON.parse(text) as {
+      schemaVersion: string;
+      task: { taskId: string };
+      readiness: { status: string };
+      compatibleExecutionProfiles: Array<{
+        executionProfileId: string;
+        profileKey: string;
+        automaticDispatch: boolean;
+      }>;
+      runs: Array<{ runId: string; status: string }>;
+      runsTruncated: boolean;
+    };
+    expect(body).toMatchObject({
+      schemaVersion: "pmh.agent-operator-task.v1",
+      task: { taskId: retained.taskId, kind: "RULE_EVIDENCE_CLAIM" },
+      readiness: { status: "HISTORICAL_ONLY" },
+      runs: [{
+        runId: retainedRun.runId,
+        status: "FAILED",
+        executionProfileId: profile.executionProfileId,
+        runOrdinal: 1,
+        terminalDiagnostic: "fixture diagnostic only",
+      }],
+      runsTruncated: false,
+      providerRequestsStartedByRead: 0,
+      modelInvocationsStartedByRead: 0,
+      fetchesStartedByRead: 0,
+      writesStartedByRead: 0,
+      runsCreatedByRead: 0,
+      automaticDispatch: false,
+      semanticDecisionAuthority: false,
+      certificateAuthority: false,
+      executionAuthority: false,
+      externalWriteAuthority: false,
+      valueMovingAuthority: false,
+    });
+    expect(body.compatibleExecutionProfiles).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        executionProfileId: profile.executionProfileId,
+        profileKey: "rule-evidence-codex-app-server",
+        automaticDispatch: false,
+      }),
+    ]));
+    expect(body.runs.map((item) => item.runId)).toEqual([retainedRun.runId]);
+    expect(text).not.toContain(otherRun.runId);
+    expect(body).not.toHaveProperty("execution");
+    expect(body).not.toHaveProperty("worldStateMechanisms");
+    expect(registry.snapshot().modelInvocations).toHaveLength(0);
+  });
+
+  it("previews one exact Agent task without creating a run or model invocation", async () => {
+    const registry = new AgentExecutionRegistry();
+    const configurationDesk = new AiRuntimeConfigurationDesk(
+      { PMH_DISCOVERY_PROVIDER: "codex" },
+      undefined,
+      () => Date.parse("2026-08-20T11:00:00.000Z"),
+    );
+    const configuration = configurationDesk.current();
+    registry.saveBatch(buildDefaultAgentRuntimePortfolio(configuration));
+    const task = buildAgentTask({
+      kind: "RELATION_DISCOVERY",
+      protocol: "RELATION_DISCOVERY_TASK_V4",
+      inputArtifacts: [],
+      taskPayload: { fixture: "operator-preview" },
+      requestedEffectProtocol: "RELATION_DISCOVERY_AGENT_TOOLS_V1",
+      provenanceRef: "fixture:operator-preview",
+      priority: 1,
+      createdAt: "2026-08-20T11:01:00.000Z",
+    });
+    registry.saveBatch({ tasks: [task] });
+    const profile = registry.snapshot().executionProfiles.find((item) =>
+      item.profileKey === "relation-discovery-codex-app-server"
+    )!;
+    const dispatcher = new AgentCampaignDispatcher({
+      registry,
+      credentialBroker: new AgentCredentialBroker([]),
+      adapters: [],
+      toolHost: {
+        manifest: () => Object.freeze([]),
+        execute: async () => Object.freeze({ status: "REJECTED" as const, output: {} }),
+      },
+      taskPayload: () => Object.freeze({ fixture: "not-read-during-preview" }),
+    });
+    const { baseUrl } = await listenControlPlane({
+      agentExecutionRegistry: registry,
+      agentCampaignDispatcher: dispatcher,
+      aiRuntimeConfigurationDesk: configurationDesk,
+    });
+    const before = registry.snapshot();
+    const response = await fetch(`${baseUrl}/api/v1/agent-tasks/${task.taskId}/runs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        mode: "PREVIEW",
+        executionProfileId: profile.executionProfileId,
+      }),
+    });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      mode: "PREVIEW",
+      preview: {
+        task: { taskId: task.taskId },
+        executionProfile: { executionProfileId: profile.executionProfileId },
+        providerRequestsStarted: 0,
+      },
+      providerRequestsStarted: 0,
+      modelInvocationsStarted: 0,
+      writesStarted: 0,
+      runsCreated: 0,
+      executionAuthority: false,
+      externalWriteAuthority: false,
+      valueMovingAuthority: false,
+    });
+    const after = registry.snapshot();
+    expect(after.runs).toEqual(before.runs);
+    expect(after.modelInvocations).toEqual(before.modelInvocations);
+    expect(after.toolEffects).toEqual(before.toolEffects);
   });
 
   it("allows incremented loopback Studio origins without reflecting remote origins", async () => {

--- a/plans/external-agent-operator-surface.md
+++ b/plans/external-agent-operator-surface.md
@@ -19,11 +19,12 @@ the running product, distinguish an offline control plane from startup work, or
 obtain bounded routing state.
 
 Grok Build topic session `61394efb-bf73-45af-aac2-a995c46d2585` was retained
-for the non-frontend audit. Its initial read expanded beyond 100k tokens without
-producing a diff; the continuation and subsequent compaction request also
-stalled. This is negative usability evidence, not implementation evidence:
-long-lived external operator sessions need proactive context budgets and Git
-state remains the acceptance boundary.
+for the non-frontend audit and implementation. Its initial read expanded beyond
+100k tokens without producing a diff; a broad continuation exhausted its turn
+budget. Two later atomic continuations produced the bounded HTTP and CLI diffs
+and focused tests. This is operational evidence for topic-session reuse with
+strict per-turn scope: long-lived external operator sessions need proactive
+context budgets, and Git state remains the acceptance boundary.
 
 ## Selected direction
 
@@ -64,10 +65,19 @@ qualification, or verification verdict logic.
   in about 0.9 seconds with one JSON envelope on stdout.
 - Every envelope still declares external writes, value movement, and live
   execution as literal `false`.
+- Exact target and task reads are bounded first-party projections. Their CLI
+  validators reject identity drift, missing authority fields, and non-zero read
+  effects rather than inferring a safe result.
+- A runnable task emits its exact compatible profile and preview command;
+  historical tasks do not emit invalid actions. Manual preview binds both
+  identities while proving zero provider/model/write/run effects and grants no
+  execute authority.
 
 ## Next implementation frontier
 
-The machine surface can discover work but cannot yet complete a useful research
-workflow. The next mainline slice should expose exact inspection for one
-selected target/task and a preview-only manual run command, then test the whole
-journey with a fresh external Agent session under an explicit context budget.
+The machine surface can now discover, inspect, and preview exact work but cannot
+yet execute and follow a research run to a retained outcome. The next mainline
+slice should require a caller-supplied authorization/idempotency reference,
+execute only a previously previewed task/profile binding, expose bounded run
+inspection and wait/resume commands, and test the whole journey with a fresh
+external Agent session under an explicit context budget.


### PR DESCRIPTION
## Why

PR #53 let an external Agent discover the product and obtain bounded routing identities. It still could not turn a selected identity into an exact, safe next operation without guessing internal HTTP routes or downloading the human Studio workspace.

## Machine journey

`agent workspace`
→ `agent target inspect <target-id>`
→ `agent task inspect <task-id>`
→ `agent task preview <task-id> <execution-profile-id>`

Every transition is emitted as an exact `allowedNextActions` command. Historical and superseded tasks remain inspectable but do not advertise invalid preview actions.

## What changed

- add bounded exact-target and exact-task control-plane projections
- retain matching allocation action, task readiness, compatible profiles, and at most 12 task-local run summaries
- add three machine-readable CLI commands and strict cross-identity validation
- extend the CLI transport with bounded JSON POST
- make manual PREVIEW explicitly prove zero provider, model, write, and run effects
- reject malformed sha256 identities before contacting the control plane
- keep execute authority absent from the preview response and next actions
- update the selected plan and CLI operating guide

## Grok Build execution evidence

The same retained topic session `61394efb-bf73-45af-aac2-a995c46d2585` was continued. A broad continuation exhausted its turn budget with zero diff. Splitting the work into atomic backend and CLI continuations produced the implementation and focused tests. Codex then reviewed the diff, removed invalid preview actions for historical tasks, replaced inferred safety fields with explicit server facts, tightened identity binding, and added no-run proof.

## Verification

- `pnpm check`
- `pnpm test`
- control plane: 120 files, 798 tests
- CLI: 22 tests
- Studio: 30 tests
- `pnpm --silent pmh help` machine-output smoke
- `git diff --check`

## Authority

This PR does not expose an execute command. Inspection and preview create no run, call no provider or model, perform no write, grant no live-trading or value-moving authority, and publish no certificate.