### PR TITLE
External Agent: execute preview-bound research runs

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -23,11 +23,11 @@ Auto Prediction now treats the internal research Agent and the external
 operator Agent as separate first-class layers. The first mainline slice makes
 `pmh` self-describing, connects it to startup readiness and a bounded Agent
 workspace, and preserves stable recovery diagnostics without copying
-control-plane verdict logic. Exact target/task inspection and a zero-effect
-manual-run preview now complete the read-to-preview journey. The next slice
-must bind an explicit authorization/idempotency reference to that preview,
-execute the research run, and expose bounded run inspection/resume while
-measuring time/context to the first retained outcome.
+control-plane verdict logic. Exact target/task inspection now leads through a
+content-addressed zero-effect preview into idempotent research execution and
+bounded exact run inspection. The next slice is wait/resume plus measured
+zero-context qualification: time, retries, payload and context to the first
+retained outcome.
 
 The product brand is **Auto Prediction**, paired conceptually with Auto Quant.
 The rename is presentation-only for now: `pmh` CLI, package scopes, environment

--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -87,6 +87,25 @@ type SearchAttentionMessage = StudioProjection["ai"]["searchAttention"]["message
 type CatalogMode = "VERIFIED_FIXTURES" | "CURRENT_OBSERVATIONS";
 type AiRuntimeConfiguration =
   StudioProjection["ai"]["runtimeConfiguration"]["configuration"];
+type ManualRunPreview = Readonly<{
+  ok: true;
+  mode: "PREVIEW";
+  binding: Readonly<{
+    schemaVersion: "pmh.agent-manual-run-preview-binding.v1";
+    taskId: string;
+    executionProfileId: string;
+    previewRef: string;
+    nextRunOrdinal: number;
+  }>;
+  providerRequestsStarted: 0;
+  modelInvocationsStarted: 0;
+  writesStarted: 0;
+  runsCreated: 0;
+  providerOrModelWorkMayStart: false;
+  tradingExecutionAuthority: false;
+  externalWriteAuthority: false;
+  valueMovingAuthority: false;
+}>;
 type AgentExecutionConsole = Readonly<{
   schemaVersion: "pmh.agent-execution-console.v1";
   summary: Readonly<{
@@ -1775,6 +1794,43 @@ const EMPTY_CATALOG_CONTEXT: StudioProjection["ai"]["catalogContext"] = {
   sourceFixtureCount: 0,
   maxListingsPerTask: 30,
 };
+
+function manualRunPreview(
+  value: unknown,
+  taskId: string,
+  executionProfileId: string,
+): ManualRunPreview {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Manual run preview response is malformed");
+  }
+  const document = value as Record<string, unknown>;
+  const binding = document.binding;
+  if (binding === null || typeof binding !== "object" || Array.isArray(binding)) {
+    throw new Error("Manual run preview binding is missing");
+  }
+  const exact = binding as Record<string, unknown>;
+  if (
+    document.ok !== true ||
+    document.mode !== "PREVIEW" ||
+    exact.schemaVersion !== "pmh.agent-manual-run-preview-binding.v1" ||
+    exact.taskId !== taskId ||
+    exact.executionProfileId !== executionProfileId ||
+    typeof exact.previewRef !== "string" ||
+    !exact.previewRef.startsWith("sha256:") ||
+    !Number.isSafeInteger(exact.nextRunOrdinal) ||
+    document.providerRequestsStarted !== 0 ||
+    document.modelInvocationsStarted !== 0 ||
+    document.writesStarted !== 0 ||
+    document.runsCreated !== 0 ||
+    document.providerOrModelWorkMayStart !== false ||
+    document.tradingExecutionAuthority !== false ||
+    document.externalWriteAuthority !== false ||
+    document.valueMovingAuthority !== false
+  ) {
+    throw new Error("Manual run preview crossed its bound zero-effect contract");
+  }
+  return value as ManualRunPreview;
+}
 
 const EMPTY_OPPORTUNITY_RADAR: StudioProjection["ai"]["opportunityRadar"] = {
   algorithmVersion: "pmh.opportunity-radar.semantic-rotation-v3",
@@ -4461,7 +4517,7 @@ function AgentOperationsView() {
   const [busy, setBusy] = useState<string | null>(null);
   const [taskId, setTaskId] = useState("");
   const [profileId, setProfileId] = useState("");
-  const [manualPreview, setManualPreview] = useState<unknown | null>(null);
+  const [manualPreview, setManualPreview] = useState<ManualRunPreview | null>(null);
 
   async function refresh() {
     const workspace = await requestAgentWorkspace();
@@ -4550,7 +4606,9 @@ function AgentOperationsView() {
     setDiagnostic(null);
     try {
       const result = await action();
-      if (key === "manual-preview") setManualPreview(result);
+      if (key === "manual-preview") {
+        setManualPreview(manualRunPreview(result, taskId, profileId));
+      }
       else setManualPreview(null);
       await refresh();
     } catch (error) {
@@ -5857,12 +5915,23 @@ function AgentOperationsView() {
               schedule: { kind: "MANUAL_ONLY", intervalMs: null },
               budget: { maximumConcurrentRuns: 1, maximumModelInvocations: 3, maximumInputTokens: "100000", maximumOutputTokens: "20000", maximumWallClockMs: 300000 },
             }))}>Create paused campaign</Button>
-            {manualPreview !== null && <Button disabled={busy !== null || selectedCapability?.dispatchEligibility !== "ELIGIBLE"} onClick={() => void perform("manual-execute", () => post(`/api/v1/agent-tasks/${taskId}/runs`, { mode: "EXECUTE", executionProfileId: profileId, authorizationRef: "operator:studio-manual" }))}><Play size={12} /> Run reviewed snapshot</Button>}
+            {manualPreview !== null && <Button disabled={busy !== null || selectedCapability?.dispatchEligibility !== "ELIGIBLE"} onClick={() => void perform("manual-execute", () => post(`/api/v1/agent-tasks/${taskId}/runs`, {
+              mode: "EXECUTE",
+              executionProfileId: profileId,
+              previewRef: manualPreview.binding.previewRef,
+              authorizationRef: `studio:${manualPreview.binding.previewRef}`,
+            }))}><Play size={12} /> Run reviewed snapshot</Button>}
           </div>
           {selectedCapability?.dispatchEligibility === "BLOCKED" && (
             <div className="inline-alert"><CircleOff size={14} />Selected profile is blocked: {selectedCapability.diagnostic}</div>
           )}
-          {manualPreview !== null && <pre className="agent-preview">{JSON.stringify(manualPreview, null, 2)}</pre>}
+          {manualPreview !== null && (
+            <div className="agent-preview">
+              <strong>Reviewed snapshot ready · run {manualPreview.binding.nextRunOrdinal}</strong>
+              <span>Executing this preview is idempotent. Reusing it returns the same run and never starts duplicate model work.</span>
+              <code>{manualPreview.binding.previewRef}</code>
+            </div>
+          )}
         </CardContent>
       </Card>
 

--- a/apps/studio/src/product-shell.css
+++ b/apps/studio/src/product-shell.css
@@ -3675,6 +3675,8 @@ footer {
 }
 
 .agent-preview {
+  display: grid;
+  gap: 5px;
   max-height: 240px;
   overflow: auto;
   margin: 14px 0 0;
@@ -3687,6 +3689,18 @@ footer {
   line-height: 1.5;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
+}
+
+.agent-preview strong {
+  color: var(--foreground);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.agent-preview code {
+  margin-top: 3px;
+  color: var(--muted-foreground);
+  font-size: 11px;
 }
 
 .agent-run-row {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -25,6 +25,8 @@ pnpm --silent pmh agent workspace
 pnpm --silent pmh agent target inspect <target-id>
 pnpm --silent pmh agent task inspect <task-id>
 pnpm --silent pmh agent task preview <task-id> <execution-profile-id>
+pnpm --silent pmh agent task execute <task-id> <execution-profile-id> <preview-ref> <authorization-ref>
+pnpm --silent pmh agent run inspect <run-id>
 pnpm --silent pmh venue list
 pnpm --silent pmh venue inspect <venue-id>
 ```
@@ -47,14 +49,29 @@ preview action.
 `agent task preview` posts `mode: PREVIEW` to the first-party manual-run route.
 The response binds the requested task and profile identities and explicitly
 reports zero provider requests, model invocations, writes, and created runs.
-It grants no execution authority and deliberately does not advertise an
-execute command. This makes the current machine journey:
+It grants no execution authority. The response supplies a content-addressed
+`previewRef` and the exact execute command. The suggested authorization ref is
+`external-agent:<previewRef>`: it is an idempotency key, not trading authority.
+
+`agent task execute` accepts only that exact task/profile/preview binding. A
+first request creates one research run and may start provider/model work; a
+retry with the same authorization ref returns the same retained run without
+starting duplicate work. Reusing an authorization ref for any other binding
+fails closed. Every response keeps trading, external-write, value-moving, and
+live-execution authority literal `false`.
+
+`agent run inspect` returns one exact run plus bounded, run-bound invocation,
+tool-effect, artifact, annotation, and result-selection collections. A prepared
+run advertises the same inspect command for polling; a terminal run points back
+to its task and workspace. This makes the current machine journey:
 
 ```text
 agent workspace
   -> agent target inspect <exact-target-id>
   -> agent task inspect <exact-task-id>
   -> agent task preview <exact-task-id> <exact-profile-id>
+  -> agent task execute <exact-task-id> <exact-profile-id> <preview-ref> external-agent:<preview-ref>
+  -> agent run inspect <exact-run-id>
 ```
 
 The default control plane is `http://127.0.0.1:4100`. Override it for another
@@ -77,7 +94,7 @@ Agents should follow that field rather than guessing a route.
 
 Unknown commands and venue identities fail closed with a non-zero process exit code and a JSON diagnostic. The present CLI cannot write external state or move value; both effects are literal `false` in every response.
 
-Authorized manual execution, exact run inspection/resume, campaign control,
+Run wait/resume, campaign control,
 catalog refresh, claim/link inspection, opportunity verification,
 deterministic replay, shadow execution, and Core projections remain planned CLI
 surfaces. Human-readable Studio views and compact CLI views consume

--- a/docs/STUDIO.md
+++ b/docs/STUDIO.md
@@ -32,6 +32,13 @@ The normal development process opens `.data/control-plane.sqlite` in WAL mode.
 publish only storage posture (`SQLITE_WAL`, schema version, durability, and
 `taskId` idempotency), never the local filesystem path.
 
+The Agent Operations manual-run control is preview-bound. Previewing starts no
+provider/model work and creates no run. Studio executes only the returned
+content-addressed snapshot and derives a stable idempotency reference from its
+`previewRef`, so a retry returns the same research run instead of spending
+twice. This authority can start bounded research model work; it never grants
+trading, external-write, value-moving, or live-execution authority.
+
 The opportunity, payoff, verifier-trace, and capital panels are now derived
 from the control plane's checked-in reviewed-compilation qualification
 artifact. The artifact is a synthetic two-venue fixture and is labeled as such

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -14,6 +14,8 @@ export const SUPPORTED_COMMANDS = Object.freeze([
   "agent target inspect <target-id>",
   "agent task inspect <task-id>",
   "agent task preview <task-id> <execution-profile-id>",
+  "agent task execute <task-id> <execution-profile-id> <preview-ref> <authorization-ref>",
+  "agent run inspect <run-id>",
   "venue list",
   "venue inspect <venue-id>",
 ] as const);
@@ -59,6 +61,18 @@ const COMMAND_CATALOG = Object.freeze([
     command: "agent task preview <task-id> <execution-profile-id>",
     kind: "CONTROL_PLANE_PREVIEW",
     description: "Preview a manual Agent run without creating a run or calling a model.",
+    requiresControlPlane: true,
+  }),
+  Object.freeze({
+    command: "agent task execute <task-id> <execution-profile-id> <preview-ref> <authorization-ref>",
+    kind: "CONTROL_PLANE_RESEARCH_DISPATCH",
+    description: "Dispatch or reuse a preview-bound manual research run. This is not live trading.",
+    requiresControlPlane: true,
+  }),
+  Object.freeze({
+    command: "agent run inspect <run-id>",
+    kind: "CONTROL_PLANE_READ",
+    description: "Inspect one Agent run and only the records bound to that run.",
     requiresControlPlane: true,
   }),
   Object.freeze({
@@ -112,6 +126,50 @@ function invalidIdentityEnvelope(
     allowedNextActions: ["agent workspace", "help"],
     ok: false,
   });
+}
+
+function invalidAuthorizationEnvelope(
+  command: string,
+  args: readonly string[],
+): CliEnvelope {
+  return createCliEnvelope({
+    command,
+    arguments: args,
+    state: null,
+    diagnostics: [{
+      severity: "ERROR",
+      code: "CLI_ARGUMENT_INVALID",
+      message: "authorization-ref must be a bounded nonblank identifier.",
+    }],
+    allowedNextActions: ["agent workspace", "help"],
+    ok: false,
+  });
+}
+
+function authorizationRefValue(value: string): boolean {
+  return value.trim() === value &&
+    /^[a-zA-Z0-9][a-zA-Z0-9._:/-]{0,159}$/u.test(value);
+}
+
+function integerValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) ? value : null;
+}
+
+function hasFalseTradingBoundary(value: JsonObject): boolean {
+  return hasLiteralFalseAuthority(value, [
+    "tradingExecutionAuthority",
+    "externalWriteAuthority",
+    "valueMovingAuthority",
+    "liveExecutionEnabled",
+  ]);
+}
+
+function previewExecuteCommand(
+  taskId: string,
+  executionProfileId: string,
+  previewRef: string,
+): string {
+  return `agent task execute ${taskId} ${executionProfileId} ${previewRef} external-agent:${previewRef}`;
 }
 
 function malformedControlPlaneEnvelope(
@@ -271,6 +329,50 @@ function validateAgentOperatorTask(value: unknown, taskId: string) {
   });
 }
 
+function validateManualRunBinding(
+  value: unknown,
+  taskId: string,
+  executionProfileId: string,
+  taskPayloadHash: string | null,
+  nextRunOrdinal: number | null,
+) {
+  const binding = objectValue(value);
+  const budget = objectValue(binding?.runBudget);
+  const previewRef = stringValue(binding?.previewRef);
+  const revision = integerValue(binding?.executionProfileRevision);
+  const boundOrdinal = integerValue(binding?.nextRunOrdinal);
+  if (
+    binding?.schemaVersion !== "pmh.agent-manual-run-preview-binding.v1" ||
+    previewRef === null ||
+    !hashValue(previewRef) ||
+    binding.taskId !== taskId ||
+    typeof binding.taskPayloadHash !== "string" ||
+    !hashValue(binding.taskPayloadHash) ||
+    (taskPayloadHash !== null && binding.taskPayloadHash !== taskPayloadHash) ||
+    binding.executionProfileId !== executionProfileId ||
+    revision === null ||
+    revision < 1 ||
+    boundOrdinal === null ||
+    boundOrdinal < 1 ||
+    (nextRunOrdinal !== null && boundOrdinal !== nextRunOrdinal) ||
+    budget === null ||
+    (integerValue(budget.maximumModelInvocations) ?? 0) < 1 ||
+    (integerValue(budget.maximumToolCalls) ?? 0) < 1 ||
+    (integerValue(budget.maximumWallClockMs) ?? 0) < 1 ||
+    !(
+      budget.maximumInputTokens === null ||
+      (typeof budget.maximumInputTokens === "string" &&
+        /^\d+$/u.test(budget.maximumInputTokens))
+    ) ||
+    !(
+      budget.maximumOutputTokens === null ||
+      (typeof budget.maximumOutputTokens === "string" &&
+        /^\d+$/u.test(budget.maximumOutputTokens))
+    )
+  ) return null;
+  return Object.freeze({ binding, previewRef, taskPayloadHash: binding.taskPayloadHash });
+}
+
 function validateManualRunPreview(
   value: unknown,
   taskId: string,
@@ -281,30 +383,215 @@ function validateManualRunPreview(
   const task = objectValue(preview?.task);
   const executionProfile = objectValue(preview?.executionProfile);
   const authority = objectValue(task?.authority);
+  const taskPayloadHash = stringValue(task?.taskPayloadHash);
+  const nextRunOrdinal = integerValue(preview?.nextRunOrdinal);
+  const bound = validateManualRunBinding(
+    document?.binding,
+    taskId,
+    executionProfileId,
+    taskPayloadHash,
+    nextRunOrdinal,
+  );
+  const budget = objectValue(bound?.binding.runBudget);
   if (
     document?.ok !== true ||
+    document.mode !== "PREVIEW" ||
     document.run !== undefined ||
     preview === null ||
     task?.schemaVersion !== "pmh.agent-task.v1" ||
     task.taskId !== taskId ||
     executionProfile?.schemaVersion !== "pmh.execution-profile.v1" ||
     executionProfile.executionProfileId !== executionProfileId ||
+    (integerValue(executionProfile.revision) !== null &&
+      integerValue(executionProfile.revision) !==
+        integerValue(bound?.binding.executionProfileRevision)) ||
     preview.providerRequestsStarted !== 0 ||
     document.providerRequestsStarted !== 0 ||
     document.modelInvocationsStarted !== 0 ||
     document.writesStarted !== 0 ||
     document.runsCreated !== 0 ||
     document.executionAuthority !== false ||
-    document.externalWriteAuthority !== false ||
-    document.valueMovingAuthority !== false ||
+    document.researchRunDispatchAuthorityConsumed !== false ||
+    document.providerOrModelWorkMayStart !== false ||
+    !hasFalseTradingBoundary(document) ||
     authority?.modelInvocations !== false ||
     authority.externalWrites !== false ||
     authority.semanticDecision !== false ||
     authority.certificatePublication !== false ||
     authority.valueMovingActions !== false ||
-    document.mode !== "PREVIEW"
+    bound === null ||
+    budget === null ||
+    (integerValue(preview.maximumModelInvocations) !== null &&
+      integerValue(preview.maximumModelInvocations) !==
+        integerValue(budget.maximumModelInvocations))
   ) return null;
-  return Object.freeze({ document, preview, task, executionProfile });
+  return Object.freeze({
+    document,
+    preview,
+    task,
+    executionProfile,
+    binding: bound.binding,
+    previewRef: bound.previewRef,
+  });
+}
+
+function validateManualRun(value: unknown, taskId: string, executionProfileId: string) {
+  const run = objectValue(value);
+  const authorization = objectValue(run?.authorization);
+  const runId = stringValue(run?.runId);
+  if (
+    run?.schemaVersion !== "pmh.agent-run.v1" ||
+    runId === null ||
+    !hashValue(runId) ||
+    run.taskId !== taskId ||
+    run.executionProfileId !== executionProfileId ||
+    authorization?.kind !== "MANUAL" ||
+    typeof authorization.authorizationRef !== "string" ||
+    run.externalWriteAuthority !== false ||
+    run.valueMovingAuthority !== false
+  ) return null;
+  return Object.freeze({ run, runId, authorizationRef: authorization.authorizationRef });
+}
+
+function validateManualRunExecute(
+  value: unknown,
+  status: number,
+  taskId: string,
+  executionProfileId: string,
+  previewRef: string,
+  authorizationRef: string,
+) {
+  const document = objectValue(value);
+  const validatedRun = validateManualRun(document?.run, taskId, executionProfileId);
+  if (
+    document?.ok !== true ||
+    document.mode !== "EXECUTE" ||
+    document.previewRef !== previewRef ||
+    validatedRun === null ||
+    validatedRun.authorizationRef !== authorizationRef ||
+    !hasLiteralFalseAuthority(document, [
+      "semanticDecisionAuthority",
+      "certificateAuthority",
+    ]) ||
+    !hasFalseTradingBoundary(document)
+  ) return null;
+  if (document.reused === true) {
+    if (
+      status !== 200 ||
+      document.dispatchStartedByRequest !== false ||
+      document.runCreatedByRequest !== false ||
+      document.executionAuthority !== false ||
+      document.researchRunDispatchAuthorityConsumed !== false ||
+      document.providerOrModelWorkMayStart !== false
+    ) return null;
+    return Object.freeze({ document, run: validatedRun.run, runId: validatedRun.runId, reused: true as const });
+  }
+  if (document.reused !== false) return null;
+  const bound = validateManualRunBinding(
+    document.binding,
+    taskId,
+    executionProfileId,
+    null,
+    integerValue(objectValue(document.preview)?.nextRunOrdinal),
+  );
+  if (
+    status !== 202 ||
+    document.dispatchStartedByRequest !== true ||
+    document.runCreatedByRequest !== true ||
+    document.executionAuthority !== true ||
+    document.researchRunDispatchAuthorityConsumed !== true ||
+    document.providerOrModelWorkMayStart !== true ||
+    bound === null ||
+    bound.previewRef !== previewRef
+  ) return null;
+  return Object.freeze({
+    document,
+    run: validatedRun.run,
+    runId: validatedRun.runId,
+    reused: false as const,
+  });
+}
+
+function runBoundCollection(
+  document: JsonObject,
+  itemsKey: string,
+  countKey: string,
+  truncatedKey: string,
+  runId: string,
+): boolean {
+  const items = document[itemsKey];
+  const count = integerValue(document[countKey]);
+  const truncated = document[truncatedKey];
+  if (!Array.isArray(items) || items.length > 32 || count === null || count < items.length ||
+      typeof truncated !== "boolean") {
+    return false;
+  }
+  if (truncated ? count <= items.length : count !== items.length) return false;
+  return items.every((item) => {
+    const record = objectValue(item);
+    if (record?.runId !== runId) return false;
+    for (const authority of [
+      "semanticDecisionAuthority",
+      "certificateAuthority",
+      "externalWriteAuthority",
+      "valueMovingAuthority",
+    ]) {
+      if (authority in record && record[authority] !== false) return false;
+    }
+    return !("responseStorage" in record && record.responseStorage !== false);
+  });
+}
+
+function validateAgentOperatorRun(value: unknown, runId: string) {
+  const document = objectValue(value);
+  const run = objectValue(document?.run);
+  const task = objectValue(document?.task);
+  const executionProfile = objectValue(document?.executionProfile);
+  const status = stringValue(run?.status);
+  if (
+    document?.schemaVersion !== "pmh.agent-operator-run.v1" ||
+    run?.schemaVersion !== "pmh.agent-run.v1" ||
+    run.runId !== runId ||
+    run.externalWriteAuthority !== false ||
+    run.valueMovingAuthority !== false ||
+    task === null ||
+    executionProfile === null ||
+    task.taskId !== run.taskId ||
+    typeof task.taskPayloadHash !== "string" ||
+    !hashValue(task.taskPayloadHash) ||
+    typeof run.taskId !== "string" ||
+    !hashValue(run.taskId) ||
+    executionProfile.executionProfileId !== run.executionProfileId ||
+    (integerValue(executionProfile.revision) ?? 0) < 1 ||
+    typeof run.executionProfileId !== "string" ||
+    !hashValue(run.executionProfileId) ||
+    status === null ||
+    !["PREPARED", "INTERRUPTED", "SUCCEEDED", "FAILED", "CANCELLED"].includes(status) ||
+    !hasZeroOperatorReadEffects(document) ||
+    document.liveExecutionEnabled !== false ||
+    document.tradingExecutionAuthority !== false ||
+    !runBoundCollection(
+      document, "modelInvocations", "modelInvocationCount", "modelInvocationsTruncated", runId,
+    ) ||
+    !runBoundCollection(
+      document, "toolEffects", "toolEffectCount", "toolEffectsTruncated", runId,
+    ) ||
+    !runBoundCollection(
+      document, "artifacts", "artifactCount", "artifactsTruncated", runId,
+    ) ||
+    !runBoundCollection(
+      document, "annotations", "annotationCount", "annotationsTruncated", runId,
+    ) ||
+    !runBoundCollection(
+      document, "resultSelections", "resultSelectionCount", "resultSelectionsTruncated", runId,
+    )
+  ) return null;
+  return Object.freeze({
+    document,
+    run,
+    taskId: run.taskId,
+    status,
+  });
 }
 
 function validateAgentOperatorWorkspace(value: unknown) {
@@ -643,15 +930,22 @@ export async function runCli(
           ok: true as const,
           controlPlaneUrl: result.baseUrl,
           preview: previewed.preview,
+          binding: previewed.binding,
+          previewRef: previewed.previewRef,
           providerRequestsStarted: 0 as const,
           modelInvocationsStarted: 0 as const,
           writesStarted: 0 as const,
           runsCreated: 0 as const,
           executionAuthority: false as const,
+          researchRunDispatchAuthorityConsumed: false as const,
+          providerOrModelWorkMayStart: false as const,
+          tradingExecutionAuthority: false as const,
           externalWriteAuthority: false as const,
           valueMovingAuthority: false as const,
+          liveExecutionEnabled: false as const,
         }),
         allowedNextActions: Object.freeze([
+          previewExecuteCommand(taskId, executionProfileId, previewed.previewRef),
           `agent task inspect ${taskId}`,
           "agent workspace",
           "help",
@@ -663,6 +957,117 @@ export async function runCli(
         taskId,
         executionProfileId,
       ]);
+    }
+  }
+
+  if (
+    namespace === "agent" &&
+    action === "task" &&
+    venueId === "execute" &&
+    extra.length === 4 &&
+    extra[0] !== undefined &&
+    extra[1] !== undefined &&
+    extra[2] !== undefined &&
+    extra[3] !== undefined
+  ) {
+    const taskId = extra[0];
+    const executionProfileId = extra[1];
+    const previewRef = extra[2];
+    const authorizationRef = extra[3];
+    const args = [taskId, executionProfileId, previewRef, authorizationRef] as const;
+    if (!hashValue(taskId) || !hashValue(executionProfileId) || !hashValue(previewRef)) {
+      return invalidIdentityEnvelope(
+        "agent.task.execute",
+        args,
+        !hashValue(taskId)
+          ? "task-id"
+          : !hashValue(executionProfileId)
+            ? "execution-profile-id"
+            : "preview-ref",
+      );
+    }
+    if (!authorizationRefValue(authorizationRef)) {
+      return invalidAuthorizationEnvelope("agent.task.execute", args);
+    }
+    const path = `/api/v1/agent-tasks/${taskId}/runs` as `/${string}`;
+    try {
+      const result = await requestControlPlaneJson(path, {
+        ...options,
+        method: "POST",
+        acceptedStatuses: Object.freeze([200, 202]),
+        body: Object.freeze({
+          mode: "EXECUTE",
+          executionProfileId,
+          previewRef,
+          authorizationRef,
+        }),
+      });
+      const executed = validateManualRunExecute(
+        result.value,
+        result.status,
+        taskId,
+        executionProfileId,
+        previewRef,
+        authorizationRef,
+      );
+      if (executed === null) {
+        return malformedControlPlaneEnvelope("agent.task.execute", path, args);
+      }
+      return createCliEnvelope({
+        command: "agent.task.execute",
+        arguments: args,
+        state: Object.freeze({
+          ...executed.document,
+          controlPlaneUrl: result.baseUrl,
+        }),
+        allowedNextActions: Object.freeze([
+          `agent run inspect ${executed.runId}`,
+          "agent workspace",
+          "help",
+        ]),
+        ok: true,
+      });
+    } catch (error) {
+      return controlPlaneFailure("agent.task.execute", error, args);
+    }
+  }
+
+  if (
+    namespace === "agent" &&
+    action === "run" &&
+    venueId === "inspect" &&
+    extra.length === 1 &&
+    extra[0] !== undefined
+  ) {
+    const runId = extra[0];
+    if (!hashValue(runId)) {
+      return invalidIdentityEnvelope("agent.run.inspect", [runId], "run-id");
+    }
+    const path = `/api/v1/agent-operator/runs/${runId}` as `/${string}`;
+    try {
+      const result = await requestControlPlaneJson(path, options);
+      const inspected = validateAgentOperatorRun(result.value, runId);
+      if (inspected === null) {
+        return malformedControlPlaneEnvelope("agent.run.inspect", path, [runId]);
+      }
+      return createCliEnvelope({
+        command: "agent.run.inspect",
+        arguments: [runId],
+        state: Object.freeze({
+          ...inspected.document,
+          controlPlaneUrl: result.baseUrl,
+        }),
+        allowedNextActions: inspected.status === "PREPARED"
+          ? Object.freeze([`agent run inspect ${runId}`])
+          : Object.freeze([
+              `agent task inspect ${inspected.taskId}`,
+              "agent workspace",
+              "help",
+            ]),
+        ok: true,
+      });
+    } catch (error) {
+      return controlPlaneFailure("agent.run.inspect", error, [runId]);
     }
   }
 

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -44,6 +44,13 @@ const TARGET_ID = `sha256:${"1".repeat(64)}`;
 const TASK_ID = `sha256:${"2".repeat(64)}`;
 const PROFILE_ID = `sha256:${"3".repeat(64)}`;
 const OTHER_ID = `sha256:${"a".repeat(64)}`;
+const TASK_PAYLOAD_HASH = `sha256:${"5".repeat(64)}`;
+const PREVIEW_REF = `sha256:${"6".repeat(64)}`;
+const RUN_ID = `sha256:${"7".repeat(64)}`;
+const OTHER_RUN_ID = `sha256:${"8".repeat(64)}`;
+const AUTH_REF = `external-agent:${PREVIEW_REF}`;
+const EXECUTE_COMMAND =
+  `agent task execute ${TASK_ID} ${PROFILE_ID} ${PREVIEW_REF} ${AUTH_REF}`;
 
 const OPERATOR_READ_EFFECTS = Object.freeze({
   providerRequestsStartedByRead: 0,
@@ -129,7 +136,15 @@ function operatorTask(taskId: string, profileId = PROFILE_ID) {
   };
 }
 
-function previewDocument(taskId: string, executionProfileId: string) {
+const RUN_BUDGET = Object.freeze({
+  maximumModelInvocations: 12,
+  maximumToolCalls: 32,
+  maximumWallClockMs: 300_000,
+  maximumInputTokens: "300000",
+  maximumOutputTokens: "30000",
+});
+
+function previewDocument(taskId: string, executionProfileId: string, previewRef = PREVIEW_REF) {
   return {
     ok: true,
     mode: "PREVIEW",
@@ -137,6 +152,7 @@ function previewDocument(taskId: string, executionProfileId: string) {
       task: {
         schemaVersion: "pmh.agent-task.v1",
         taskId,
+        taskPayloadHash: TASK_PAYLOAD_HASH,
         kind: "RELATION_DISCOVERY",
         authority: TASK_AUTHORITY,
       },
@@ -144,18 +160,131 @@ function previewDocument(taskId: string, executionProfileId: string) {
         schemaVersion: "pmh.execution-profile.v1",
         executionProfileId,
         profileKey: "relation-discovery-codex-app-server",
+        revision: 2,
       },
       nextRunOrdinal: 1,
       maximumModelInvocations: 12,
       providerRequestsStarted: 0,
+    },
+    binding: {
+      schemaVersion: "pmh.agent-manual-run-preview-binding.v1",
+      previewRef,
+      taskId,
+      taskPayloadHash: TASK_PAYLOAD_HASH,
+      executionProfileId,
+      executionProfileRevision: 2,
+      nextRunOrdinal: 1,
+      runBudget: RUN_BUDGET,
     },
     providerRequestsStarted: 0,
     modelInvocationsStarted: 0,
     writesStarted: 0,
     runsCreated: 0,
     executionAuthority: false,
+    researchRunDispatchAuthorityConsumed: false,
+    providerOrModelWorkMayStart: false,
+    tradingExecutionAuthority: false,
     externalWriteAuthority: false,
     valueMovingAuthority: false,
+    liveExecutionEnabled: false,
+  };
+}
+
+function manualRun(runId: string, taskId: string, executionProfileId: string, status = "PREPARED") {
+  return {
+    schemaVersion: "pmh.agent-run.v1",
+    runId,
+    taskId,
+    executionProfileId,
+    runOrdinal: 1,
+    status,
+    authorization: {
+      kind: "MANUAL",
+      authorizationRef: AUTH_REF,
+      campaignId: null,
+      authorizedAt: "2026-08-20T15:00:00.000Z",
+    },
+    createdAt: "2026-08-20T15:00:00.000Z",
+    completedAt: status === "PREPARED" ? null : "2026-08-20T15:01:00.000Z",
+    terminalDiagnostic: status === "PREPARED" ? null : "fixture",
+    externalWriteAuthority: false,
+    valueMovingAuthority: false,
+  };
+}
+
+function executeDocument(input: {
+  reused: boolean;
+  runId?: string;
+  taskId?: string;
+  executionProfileId?: string;
+  previewRef?: string;
+  executionAuthority?: boolean;
+}) {
+  const reused = input.reused;
+  const taskId = input.taskId ?? TASK_ID;
+  const executionProfileId = input.executionProfileId ?? PROFILE_ID;
+  const previewRef = input.previewRef ?? PREVIEW_REF;
+  return {
+    ok: true,
+    mode: "EXECUTE",
+    reused,
+    run: manualRun(input.runId ?? RUN_ID, taskId, executionProfileId),
+    previewRef,
+    ...(reused
+      ? {}
+      : {
+          binding: previewDocument(taskId, executionProfileId, previewRef).binding,
+          preview: previewDocument(taskId, executionProfileId, previewRef).preview,
+        }),
+    dispatchStartedByRequest: !reused,
+    runCreatedByRequest: !reused,
+    executionAuthority: input.executionAuthority ?? !reused,
+    researchRunDispatchAuthorityConsumed: !reused,
+    providerOrModelWorkMayStart: !reused,
+    semanticDecisionAuthority: false,
+    certificateAuthority: false,
+    tradingExecutionAuthority: false,
+    externalWriteAuthority: false,
+    valueMovingAuthority: false,
+    liveExecutionEnabled: false,
+  };
+}
+
+function operatorRun(runId: string, status = "PREPARED", leakedRunId?: string) {
+  return {
+    schemaVersion: "pmh.agent-operator-run.v1",
+    run: manualRun(runId, TASK_ID, PROFILE_ID, status),
+    task: {
+      taskId: TASK_ID,
+      kind: "RELATION_DISCOVERY",
+      taskPayloadHash: TASK_PAYLOAD_HASH,
+      protocol: "RELATION_DISCOVERY_TASK_V4",
+    },
+    executionProfile: {
+      executionProfileId: PROFILE_ID,
+      profileKey: "relation-discovery-codex-app-server",
+      revision: 2,
+    },
+    modelInvocations: [],
+    modelInvocationCount: 0,
+    modelInvocationsTruncated: false,
+    toolEffects: [],
+    toolEffectCount: 0,
+    toolEffectsTruncated: false,
+    artifacts: [],
+    artifactCount: 0,
+    artifactsTruncated: false,
+    annotations: leakedRunId === undefined
+      ? []
+      : [{ runId: leakedRunId, annotationId: OTHER_ID, category: "LEAK" }],
+    annotationCount: leakedRunId === undefined ? 0 : 1,
+    annotationsTruncated: false,
+    resultSelections: [],
+    resultSelectionCount: 0,
+    resultSelectionsTruncated: false,
+    ...OPERATOR_READ_EFFECTS,
+    tradingExecutionAuthority: false,
+    liveExecutionEnabled: false,
   };
 }
 
@@ -175,6 +304,10 @@ describe("versioned CLI envelope", () => {
     expect(result.allowedNextActions).toContain(
       "agent task preview <task-id> <execution-profile-id>",
     );
+    expect(result.allowedNextActions).toContain(
+      "agent task execute <task-id> <execution-profile-id> <preview-ref> <authorization-ref>",
+    );
+    expect(result.allowedNextActions).toContain("agent run inspect <run-id>");
   });
 
   it("reports the system's Node 22 baseline and live-disabled boundary", async () => {
@@ -562,25 +695,34 @@ describe("versioned CLI envelope", () => {
     expect(result.state).toMatchObject({
       mode: "PREVIEW",
       preview: {
-        task: { taskId: TASK_ID },
+        task: { taskId: TASK_ID, taskPayloadHash: TASK_PAYLOAD_HASH },
         executionProfile: { executionProfileId: PROFILE_ID },
         providerRequestsStarted: 0,
       },
+      binding: {
+        schemaVersion: "pmh.agent-manual-run-preview-binding.v1",
+        previewRef: PREVIEW_REF,
+        taskId: TASK_ID,
+        executionProfileId: PROFILE_ID,
+      },
+      previewRef: PREVIEW_REF,
       providerRequestsStarted: 0,
       modelInvocationsStarted: 0,
       writesStarted: 0,
       runsCreated: 0,
       executionAuthority: false,
-      externalWriteAuthority: false,
-      valueMovingAuthority: false,
+      researchRunDispatchAuthorityConsumed: false,
+      providerOrModelWorkMayStart: false,
+      tradingExecutionAuthority: false,
+      liveExecutionEnabled: false,
     });
     expect(result.state).not.toHaveProperty("run");
     expect(result.allowedNextActions).toEqual([
+      EXECUTE_COMMAND,
       `agent task inspect ${TASK_ID}`,
       "agent workspace",
       "help",
     ]);
-    expect(result.allowedNextActions.join(" ")).not.toMatch(/execute/i);
     expect(result.effects.liveExecutionEnabled).toBe(false);
   });
 
@@ -614,6 +756,195 @@ describe("versioned CLI envelope", () => {
       code: "CONTROL_PLANE_HTTP_ERROR",
       message: expect.stringContaining("Agent task is unavailable"),
     });
+  });
+
+  it("rejects a preview whose binding identities do not match the request", async () => {
+    const baseUrl = await serve(async (request, response) => {
+      await readJsonBody(request);
+      json(response, previewDocument(TASK_ID, OTHER_ID));
+    });
+    const result = await runCli(
+      ["agent", "task", "preview", TASK_ID, PROFILE_ID],
+      { baseUrl },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0]?.code).toBe("CONTROL_PLANE_MALFORMED_RESPONSE");
+  });
+
+  it("executes a preview-bound research run without trading authority", async () => {
+    const baseUrl = await serve(async (request, response) => {
+      expect(request.method).toBe("POST");
+      expect(request.url).toBe(`/api/v1/agent-tasks/${TASK_ID}/runs`);
+      expect(await readJsonBody(request)).toEqual({
+        mode: "EXECUTE",
+        executionProfileId: PROFILE_ID,
+        previewRef: PREVIEW_REF,
+        authorizationRef: AUTH_REF,
+      });
+      json(response, executeDocument({ reused: false }), 202);
+    });
+    const result = await runCli(
+      ["agent", "task", "execute", TASK_ID, PROFILE_ID, PREVIEW_REF, AUTH_REF],
+      { baseUrl },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.identity.command).toBe("agent.task.execute");
+    expect(result.state).toMatchObject({
+      reused: false,
+      run: { runId: RUN_ID, taskId: TASK_ID },
+      previewRef: PREVIEW_REF,
+      dispatchStartedByRequest: true,
+      runCreatedByRequest: true,
+      executionAuthority: true,
+      researchRunDispatchAuthorityConsumed: true,
+      providerOrModelWorkMayStart: true,
+      tradingExecutionAuthority: false,
+      liveExecutionEnabled: false,
+    });
+    expect(result.allowedNextActions).toEqual([
+      `agent run inspect ${RUN_ID}`,
+      "agent workspace",
+      "help",
+    ]);
+    expect(result.effects).toEqual({
+      externalWrites: false,
+      valueMovingActions: false,
+      liveExecutionEnabled: false,
+    });
+  });
+
+  it("reuses an idempotent execute without dispatching another run", async () => {
+    const baseUrl = await serve(async (request, response) => {
+      expect(await readJsonBody(request)).toMatchObject({
+        mode: "EXECUTE",
+        previewRef: PREVIEW_REF,
+        authorizationRef: AUTH_REF,
+      });
+      json(response, executeDocument({ reused: true }), 200);
+    });
+    const result = await runCli(
+      ["agent", "task", "execute", TASK_ID, PROFILE_ID, PREVIEW_REF, AUTH_REF],
+      { baseUrl },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.state).toMatchObject({
+      reused: true,
+      run: { runId: RUN_ID },
+      previewRef: PREVIEW_REF,
+      dispatchStartedByRequest: false,
+      runCreatedByRequest: false,
+      executionAuthority: false,
+      researchRunDispatchAuthorityConsumed: false,
+      providerOrModelWorkMayStart: false,
+      tradingExecutionAuthority: false,
+    });
+    expect(result.allowedNextActions[0]).toBe(`agent run inspect ${RUN_ID}`);
+    expect(result.effects.liveExecutionEnabled).toBe(false);
+  });
+
+  it("rejects execute responses that mix research-run and trading authority", async () => {
+    const baseUrl = await serve(async (request, response) => {
+      await readJsonBody(request);
+      json(response, {
+        ...executeDocument({ reused: true, executionAuthority: true }),
+      }, 200);
+    });
+    const result = await runCli(
+      ["agent", "task", "execute", TASK_ID, PROFILE_ID, PREVIEW_REF, AUTH_REF],
+      { baseUrl },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0]?.code).toBe("CONTROL_PLANE_MALFORMED_RESPONSE");
+  });
+
+  it("rejects an execute whose returned run identity does not match the request", async () => {
+    const baseUrl = await serve(async (request, response) => {
+      await readJsonBody(request);
+      json(response, executeDocument({ reused: false, taskId: OTHER_ID }), 202);
+    });
+    const result = await runCli(
+      ["agent", "task", "execute", TASK_ID, PROFILE_ID, PREVIEW_REF, AUTH_REF],
+      { baseUrl },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0]?.code).toBe("CONTROL_PLANE_MALFORMED_RESPONSE");
+  });
+
+  it("inspects a PREPARED run with a polling next action", async () => {
+    const baseUrl = await serve((request, response) => {
+      expect(request.method).toBe("GET");
+      expect(request.url).toBe(`/api/v1/agent-operator/runs/${RUN_ID}`);
+      json(response, operatorRun(RUN_ID, "PREPARED"));
+    });
+    const result = await runCli(["agent", "run", "inspect", RUN_ID], { baseUrl });
+    expect(result.ok).toBe(true);
+    expect(result.state).toMatchObject({
+      schemaVersion: "pmh.agent-operator-run.v1",
+      run: { runId: RUN_ID, status: "PREPARED" },
+      task: { taskId: TASK_ID },
+      executionProfile: { executionProfileId: PROFILE_ID },
+      modelInvocationCount: 0,
+      annotationsTruncated: false,
+      providerRequestsStartedByRead: 0,
+      tradingExecutionAuthority: false,
+      liveExecutionEnabled: false,
+    });
+    expect(result.allowedNextActions).toEqual([`agent run inspect ${RUN_ID}`]);
+  });
+
+  it("inspects a terminal run and returns exact task inspect next actions", async () => {
+    const baseUrl = await serve((_request, response) =>
+      json(response, operatorRun(RUN_ID, "FAILED"))
+    );
+    const result = await runCli(["agent", "run", "inspect", RUN_ID], { baseUrl });
+    expect(result.ok).toBe(true);
+    expect(result.allowedNextActions).toEqual([
+      `agent task inspect ${TASK_ID}`,
+      "agent workspace",
+      "help",
+    ]);
+  });
+
+  it("rejects a run inspect that leaks another run's records", async () => {
+    const baseUrl = await serve((_request, response) =>
+      json(response, operatorRun(RUN_ID, "PREPARED", OTHER_RUN_ID))
+    );
+    const result = await runCli(["agent", "run", "inspect", RUN_ID], { baseUrl });
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0]?.code).toBe("CONTROL_PLANE_MALFORMED_RESPONSE");
+  });
+
+  it("rejects malformed execute and run identities without HTTP", async () => {
+    let requested = false;
+    const host = {
+      fetchImpl: async () => {
+        requested = true;
+        throw new Error("must not request");
+      },
+    };
+    const badHash = await runCli(
+      ["agent", "task", "execute", "not-a-hash", PROFILE_ID, PREVIEW_REF, AUTH_REF],
+      host,
+    );
+    expect(badHash.ok).toBe(false);
+    expect(badHash.diagnostics[0]).toMatchObject({
+      code: "CLI_ARGUMENT_INVALID",
+      message: "task-id must be an exact sha256 identity.",
+    });
+    const blankAuth = await runCli(
+      ["agent", "task", "execute", TASK_ID, PROFILE_ID, PREVIEW_REF, "  "],
+      host,
+    );
+    expect(blankAuth.diagnostics[0]).toMatchObject({
+      code: "CLI_ARGUMENT_INVALID",
+      message: "authorization-ref must be a bounded nonblank identifier.",
+    });
+    const badRun = await runCli(["agent", "run", "inspect", "../runs"], host);
+    expect(badRun.diagnostics[0]).toMatchObject({
+      code: "CLI_ARGUMENT_INVALID",
+      message: "run-id must be an exact sha256 identity.",
+    });
+    expect(requested).toBe(false);
   });
 
   it("inspects validated venue capability evidence", async () => {

--- a/packages/control-plane/src/agent-manual-run-preview-binding.ts
+++ b/packages/control-plane/src/agent-manual-run-preview-binding.ts
@@ -1,0 +1,51 @@
+import { hashCanonical, type Hash } from "@pmh/domain";
+import type { ManualAgentDispatchPreview } from "./agent-campaign-dispatcher.js";
+
+export const AGENT_MANUAL_RUN_PREVIEW_BINDING_SCHEMA =
+  "pmh.agent-manual-run-preview-binding.v1" as const;
+
+export type AgentManualRunPreviewBinding = Readonly<{
+  schemaVersion: typeof AGENT_MANUAL_RUN_PREVIEW_BINDING_SCHEMA;
+  previewRef: Hash;
+  taskId: Hash;
+  taskPayloadHash: Hash;
+  executionProfileId: Hash;
+  executionProfileRevision: number;
+  nextRunOrdinal: number;
+  runBudget: ManualAgentDispatchPreview["executionProfile"]["runBudget"];
+}>;
+
+function bindingBody(
+  preview: ManualAgentDispatchPreview,
+): Omit<AgentManualRunPreviewBinding, "previewRef"> {
+  return Object.freeze({
+    schemaVersion: AGENT_MANUAL_RUN_PREVIEW_BINDING_SCHEMA,
+    taskId: preview.task.taskId,
+    taskPayloadHash: preview.task.taskPayloadHash,
+    executionProfileId: preview.executionProfile.executionProfileId,
+    executionProfileRevision: preview.executionProfile.revision,
+    nextRunOrdinal: preview.nextRunOrdinal,
+    runBudget: preview.executionProfile.runBudget,
+  });
+}
+
+export function buildAgentManualRunPreviewBinding(
+  preview: ManualAgentDispatchPreview,
+): AgentManualRunPreviewBinding {
+  const body = bindingBody(preview);
+  return Object.freeze({
+    ...body,
+    previewRef: hashCanonical(body),
+  });
+}
+
+export function currentManualRunPreviewBinding(
+  preview: ManualAgentDispatchPreview,
+  previewRef: unknown,
+): AgentManualRunPreviewBinding {
+  const current = buildAgentManualRunPreviewBinding(preview);
+  if (typeof previewRef !== "string" || previewRef !== current.previewRef) {
+    throw new Error("manual Agent run previewRef is stale or mismatched");
+  }
+  return current;
+}

--- a/packages/control-plane/src/server.ts
+++ b/packages/control-plane/src/server.ts
@@ -507,6 +507,7 @@ import {
 import {
   AgentExecutionRegistry,
   activateAgentCampaign,
+  buildAgentRunAnnotation,
   buildPausedAgentCampaign,
   buildRuleEvidenceAgentTask,
   buildRuleEvidenceAgentTaskPayload,
@@ -527,6 +528,10 @@ import { buildDefaultAgentRuntimePortfolio } from "./agent-runtime-portfolio.js"
 import {
   AgentCampaignDispatcher,
 } from "./agent-campaign-dispatcher.js";
+import {
+  buildAgentManualRunPreviewBinding,
+  currentManualRunPreviewBinding,
+} from "./agent-manual-run-preview-binding.js";
 import {
   agentInputRevisionAnnotationMatches,
   buildAgentInputRevisionRunAnnotation,
@@ -6858,6 +6863,114 @@ export function createControlPlane(options?: {
       }), { "cache-control": "no-store" });
       return;
     }
+    const operatorRunMatch = url.pathname.match(
+      /^\/api\/v1\/agent-operator\/runs\/(sha256:[0-9a-f]{64})$/u,
+    );
+    if (request.method === "GET" && operatorRunMatch !== null) {
+      await ready;
+      const snapshot = agentExecutionRegistry.snapshot();
+      const runId = operatorRunMatch[1] as Hash;
+      const run = snapshot.runs.find((item) => item.runId === runId);
+      const operatorReadEffects = Object.freeze({
+        providerRequestsStartedByRead: 0 as const,
+        modelInvocationsStartedByRead: 0 as const,
+        fetchesStartedByRead: 0 as const,
+        writesStartedByRead: 0 as const,
+        runsCreatedByRead: 0 as const,
+        automaticDispatch: false as const,
+        semanticDecisionAuthority: false as const,
+        certificateAuthority: false as const,
+        executionAuthority: false as const,
+        externalWriteAuthority: false as const,
+        valueMovingAuthority: false as const,
+        liveExecutionEnabled: false as const,
+      });
+      if (run === undefined) {
+        writeJson(response, 404, Object.freeze({
+          ok: false as const,
+          diagnostic: `Agent run ${runId} was not found`,
+          ...operatorReadEffects,
+        }), { "cache-control": "no-store" });
+        return;
+      }
+      const task = snapshot.tasks.find((item) => item.taskId === run.taskId);
+      const profile = snapshot.executionProfiles.find((item) =>
+        item.executionProfileId === run.executionProfileId
+      );
+      const capCollection = <T,>(
+        items: readonly T[],
+        cap = 32,
+      ): Readonly<{
+        items: readonly T[];
+        count: number;
+        truncated: boolean;
+      }> => Object.freeze({
+        items: Object.freeze(items.slice(0, cap)),
+        count: items.length,
+        truncated: items.length > cap,
+      });
+      const modelInvocations = capCollection(
+        snapshot.modelInvocations.filter((item) => item.runId === runId)
+          .sort((left, right) => left.ordinal - right.ordinal ||
+            left.invocationId.localeCompare(right.invocationId)),
+      );
+      const toolEffects = capCollection(
+        snapshot.toolEffects.filter((item) => item.runId === runId)
+          .sort((left, right) => left.ordinal - right.ordinal ||
+            left.effectId.localeCompare(right.effectId)),
+      );
+      const artifacts = capCollection(
+        snapshot.runArtifacts.filter((item) => item.runId === runId)
+          .sort((left, right) => left.ordinal - right.ordinal ||
+            left.artifactId.localeCompare(right.artifactId)),
+      );
+      const annotations = capCollection(
+        snapshot.runAnnotations.filter((item) => item.runId === runId)
+          .sort((left, right) => left.createdAt.localeCompare(right.createdAt) ||
+            left.annotationId.localeCompare(right.annotationId)),
+      );
+      const resultSelections = capCollection(
+        snapshot.resultSelections.filter((item) => item.runId === runId)
+          .sort((left, right) => left.selectedAt.localeCompare(right.selectedAt) ||
+            left.selectionId.localeCompare(right.selectionId)),
+      );
+      writeJson(response, 200, Object.freeze({
+        schemaVersion: "pmh.agent-operator-run.v1" as const,
+        run,
+        task: task === undefined
+          ? null
+          : Object.freeze({
+              taskId: task.taskId,
+              kind: task.kind,
+              taskPayloadHash: task.taskPayloadHash,
+              protocol: task.protocol,
+            }),
+        executionProfile: profile === undefined
+          ? null
+          : Object.freeze({
+              executionProfileId: profile.executionProfileId,
+              profileKey: profile.profileKey,
+              revision: profile.revision,
+            }),
+        modelInvocations: modelInvocations.items,
+        modelInvocationCount: modelInvocations.count,
+        modelInvocationsTruncated: modelInvocations.truncated,
+        toolEffects: toolEffects.items,
+        toolEffectCount: toolEffects.count,
+        toolEffectsTruncated: toolEffects.truncated,
+        artifacts: artifacts.items,
+        artifactCount: artifacts.count,
+        artifactsTruncated: artifacts.truncated,
+        annotations: annotations.items,
+        annotationCount: annotations.count,
+        annotationsTruncated: annotations.truncated,
+        resultSelections: resultSelections.items,
+        resultSelectionCount: resultSelections.count,
+        resultSelectionsTruncated: resultSelections.truncated,
+        ...operatorReadEffects,
+      }), { "cache-control": "no-store" });
+      return;
+    }
     if (
       request.method === "GET" &&
       url.pathname === "/api/v1/discovery-execution-capability"
@@ -8779,52 +8892,154 @@ export function createControlPlane(options?: {
         const body = await readJson(request) as Record<string, unknown>;
         if (body === null || typeof body !== "object" || Array.isArray(body) ||
             !["PREVIEW", "EXECUTE"].includes(String(body.mode)) ||
-            typeof body.executionProfileId !== "string" ||
-            (body.mode === "EXECUTE" && typeof body.authorizationRef !== "string")) {
+            typeof body.executionProfileId !== "string") {
           throw new Error("manual Agent run request is malformed");
         }
-        const preview = agentCampaignDispatcher.previewManual(
-          manualAgentRunMatch[1] as Hash,
-          body.executionProfileId as Hash,
-        );
+        const taskId = manualAgentRunMatch[1] as Hash;
+        const executionProfileId = body.executionProfileId as Hash;
+        const manualAuthority = Object.freeze({
+          semanticDecisionAuthority: false as const,
+          certificateAuthority: false as const,
+          tradingExecutionAuthority: false as const,
+          externalWriteAuthority: false as const,
+          valueMovingAuthority: false as const,
+          liveExecutionEnabled: false as const,
+        });
         if (body.mode === "PREVIEW") {
+          const preview = agentCampaignDispatcher.previewManual(
+            taskId,
+            executionProfileId,
+          );
           writeJson(response, 200, {
             ok: true,
             mode: "PREVIEW" as const,
             preview,
+            binding: buildAgentManualRunPreviewBinding(preview),
             providerRequestsStarted: 0 as const,
             modelInvocationsStarted: 0 as const,
             writesStarted: 0 as const,
             runsCreated: 0 as const,
             executionAuthority: false as const,
-            externalWriteAuthority: false as const,
-            valueMovingAuthority: false as const,
+            researchRunDispatchAuthorityConsumed: false as const,
+            providerOrModelWorkMayStart: false as const,
+            ...manualAuthority,
           });
         } else {
-          const dispatched = agentCampaignDispatcher.dispatchManual(
-            manualAgentRunMatch[1] as Hash,
-            body.executionProfileId as Hash,
-            body.authorizationRef as string,
-          );
-          void broadcastProjection();
-          void dispatched.completion.then(
-            () => reconcileAfterAgentTaskCompletion(dispatched.run.taskId),
-            () => reconcileAfterAgentTaskCompletion(dispatched.run.taskId),
-          );
-          writeJson(response, 202, {
-            ok: true,
-            run: dispatched.run,
-            preview,
-            externalWriteAuthority: false,
-            valueMovingAuthority: false,
-          });
+          const keys = Object.keys(body).sort();
+          if (
+            keys.length !== 4 ||
+            keys[0] !== "authorizationRef" ||
+            keys[1] !== "executionProfileId" ||
+            keys[2] !== "mode" ||
+            keys[3] !== "previewRef" ||
+            typeof body.previewRef !== "string" ||
+            typeof body.authorizationRef !== "string"
+          ) {
+            throw new Error("manual Agent run request is malformed");
+          }
+          const retainedSnapshot = agentExecutionRegistry.snapshot();
+          const retained = retainedSnapshot.runs
+            .filter((run) => run.authorization.kind === "MANUAL" &&
+              run.authorization.authorizationRef === body.authorizationRef)
+            .sort((left, right) =>
+              left.createdAt.localeCompare(right.createdAt) ||
+              left.runId.localeCompare(right.runId)
+            );
+          if (retained.some((run) =>
+            run.taskId !== taskId || run.executionProfileId !== executionProfileId
+          )) {
+            throw new Error(
+              "manual authorizationRef is already bound to another task or execution profile",
+            );
+          }
+          const existing = retained[0];
+          if (existing !== undefined) {
+            if (retained.length !== 1) {
+              throw new Error(
+                "manual authorizationRef is bound to more than one retained run",
+              );
+            }
+            const bindingAnnotation = retainedSnapshot.runAnnotations.find((item) =>
+              item.runId === existing.runId &&
+              item.category === "MANUAL_PREVIEW_BINDING"
+            );
+            if (
+              bindingAnnotation === undefined ||
+              bindingAnnotation.sourceRecordRef !== `manual-preview:${body.previewRef}`
+            ) {
+              throw new Error(
+                "manual authorizationRef is not bound to the requested previewRef",
+              );
+            }
+            writeJson(response, 200, {
+              ok: true,
+              mode: "EXECUTE" as const,
+              reused: true as const,
+              run: existing,
+              previewRef: body.previewRef,
+              dispatchStartedByRequest: false as const,
+              runCreatedByRequest: false as const,
+              executionAuthority: false as const,
+              researchRunDispatchAuthorityConsumed: false as const,
+              providerOrModelWorkMayStart: false as const,
+              ...manualAuthority,
+            });
+          } else {
+            const preview = agentCampaignDispatcher.previewManual(
+              taskId,
+              executionProfileId,
+            );
+            const binding = currentManualRunPreviewBinding(preview, body.previewRef);
+            const dispatched = agentCampaignDispatcher.dispatchManual(
+              taskId,
+              executionProfileId,
+              body.authorizationRef,
+            );
+            agentExecutionRegistry.saveBatch({
+              runAnnotations: [buildAgentRunAnnotation({
+                run: dispatched.run,
+                category: "MANUAL_PREVIEW_BINDING",
+                sourceRecordRef: `manual-preview:${binding.previewRef}`,
+                observedFacts: binding,
+                note: "Manual Agent run authorization is bound to this exact preview.",
+                createdAt: dispatched.run.createdAt,
+              })],
+            });
+            void broadcastProjection();
+            void dispatched.completion.then(
+              () => reconcileAfterAgentTaskCompletion(dispatched.run.taskId),
+              () => reconcileAfterAgentTaskCompletion(dispatched.run.taskId),
+            );
+            writeJson(response, 202, {
+              ok: true,
+              mode: "EXECUTE" as const,
+              reused: false as const,
+              run: dispatched.run,
+              binding,
+              previewRef: binding.previewRef,
+              preview,
+              dispatchStartedByRequest: true as const,
+              runCreatedByRequest: true as const,
+              executionAuthority: true as const,
+              researchRunDispatchAuthorityConsumed: true as const,
+              providerOrModelWorkMayStart: true as const,
+              ...manualAuthority,
+            });
+          }
         }
       } catch (error) {
         writeJson(response, 409, {
           ok: false,
           diagnostic: error instanceof Error ? error.message : "manual Agent run failed",
+          semanticDecisionAuthority: false,
+          certificateAuthority: false,
+          executionAuthority: false,
+          researchRunDispatchAuthorityConsumed: false,
+          providerOrModelWorkMayStart: false,
+          tradingExecutionAuthority: false,
           externalWriteAuthority: false,
           valueMovingAuthority: false,
+          liveExecutionEnabled: false,
         });
       }
       return;

--- a/packages/control-plane/test/server.test.ts
+++ b/packages/control-plane/test/server.test.ts
@@ -827,13 +827,33 @@ describe("control-plane HTTP surface", () => {
       }),
     });
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toMatchObject({
+    const previewed = await response.json() as {
+      binding: {
+        schemaVersion: string;
+        previewRef: string;
+        taskId: string;
+        taskPayloadHash: string;
+        executionProfileId: string;
+        executionProfileRevision: number;
+        nextRunOrdinal: number;
+      };
+    };
+    expect(previewed).toMatchObject({
       ok: true,
       mode: "PREVIEW",
       preview: {
         task: { taskId: task.taskId },
         executionProfile: { executionProfileId: profile.executionProfileId },
         providerRequestsStarted: 0,
+      },
+      binding: {
+        schemaVersion: "pmh.agent-manual-run-preview-binding.v1",
+        taskId: task.taskId,
+        taskPayloadHash: task.taskPayloadHash,
+        executionProfileId: profile.executionProfileId,
+        executionProfileRevision: profile.revision,
+        nextRunOrdinal: 1,
+        runBudget: profile.runBudget,
       },
       providerRequestsStarted: 0,
       modelInvocationsStarted: 0,
@@ -843,10 +863,364 @@ describe("control-plane HTTP surface", () => {
       externalWriteAuthority: false,
       valueMovingAuthority: false,
     });
+    expect(previewed.binding.previewRef).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(previewed.binding.previewRef).toBe(hashCanonical({
+      schemaVersion: "pmh.agent-manual-run-preview-binding.v1",
+      taskId: task.taskId,
+      taskPayloadHash: task.taskPayloadHash,
+      executionProfileId: profile.executionProfileId,
+      executionProfileRevision: profile.revision,
+      nextRunOrdinal: 1,
+      runBudget: profile.runBudget,
+    }));
     const after = registry.snapshot();
     expect(after.runs).toEqual(before.runs);
     expect(after.modelInvocations).toEqual(before.modelInvocations);
     expect(after.toolEffects).toEqual(before.toolEffects);
+  });
+
+  it("binds previewRef to current state and executes with authorization idempotency", async () => {
+    const registry = new AgentExecutionRegistry();
+    const configurationDesk = new AiRuntimeConfigurationDesk(
+      { PMH_DISCOVERY_PROVIDER: "codex" },
+      undefined,
+      () => Date.parse("2026-08-20T12:00:00.000Z"),
+    );
+    registry.saveBatch(buildDefaultAgentRuntimePortfolio(configurationDesk.current()));
+    const task = buildAgentTask({
+      kind: "RELATION_DISCOVERY",
+      protocol: "RELATION_DISCOVERY_TASK_V4",
+      inputArtifacts: [],
+      taskPayload: { fixture: "operator-execute" },
+      requestedEffectProtocol: "RELATION_DISCOVERY_AGENT_TOOLS_V1",
+      provenanceRef: "fixture:operator-execute",
+      priority: 1,
+      createdAt: "2026-08-20T12:01:00.000Z",
+    });
+    const other = buildAgentTask({
+      kind: "RELATION_DISCOVERY",
+      protocol: "RELATION_DISCOVERY_TASK_V4",
+      inputArtifacts: [],
+      taskPayload: { fixture: "operator-execute-other" },
+      requestedEffectProtocol: "RELATION_DISCOVERY_AGENT_TOOLS_V1",
+      provenanceRef: "fixture:operator-execute-other",
+      priority: 2,
+      createdAt: "2026-08-20T12:02:00.000Z",
+    });
+    registry.saveBatch({ tasks: [task, other] });
+    const profile = registry.snapshot().executionProfiles.find((item) =>
+      item.profileKey === "relation-discovery-codex-app-server"
+    )!;
+    const dispatcher = new AgentCampaignDispatcher({
+      registry,
+      credentialBroker: new AgentCredentialBroker([]),
+      adapters: [],
+      toolHost: {
+        manifest: () => Object.freeze([]),
+        execute: async () => Object.freeze({ status: "REJECTED" as const, output: {} }),
+      },
+      taskPayload: () => Object.freeze({ fixture: "operator-execute" }),
+    });
+    const { baseUrl } = await listenControlPlane({
+      agentExecutionRegistry: registry,
+      agentCampaignDispatcher: dispatcher,
+      aiRuntimeConfigurationDesk: configurationDesk,
+    });
+
+    const firstPreview = await fetch(`${baseUrl}/api/v1/agent-tasks/${task.taskId}/runs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        mode: "PREVIEW",
+        executionProfileId: profile.executionProfileId,
+      }),
+    }).then((response) => response.json()) as {
+      binding: { previewRef: string; nextRunOrdinal: number };
+    };
+    expect(firstPreview.binding.nextRunOrdinal).toBe(1);
+
+    const malformedExecute = await fetch(`${baseUrl}/api/v1/agent-tasks/${task.taskId}/runs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        mode: "EXECUTE",
+        executionProfileId: profile.executionProfileId,
+        authorizationRef: "operator:manual-a",
+      }),
+    });
+    expect(malformedExecute.status).toBe(409);
+    expect(registry.snapshot().runs).toHaveLength(0);
+
+    const created = await fetch(`${baseUrl}/api/v1/agent-tasks/${task.taskId}/runs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        mode: "EXECUTE",
+        executionProfileId: profile.executionProfileId,
+        previewRef: firstPreview.binding.previewRef,
+        authorizationRef: "operator:manual-a",
+      }),
+    });
+    expect(created.status).toBe(202);
+    const createdBody = await created.json() as {
+      reused: boolean;
+      run: { runId: string; taskId: string; executionProfileId: string };
+    };
+    expect(createdBody).toMatchObject({
+      ok: true,
+      mode: "EXECUTE",
+      reused: false,
+      run: {
+        taskId: task.taskId,
+        executionProfileId: profile.executionProfileId,
+        authorization: { kind: "MANUAL", authorizationRef: "operator:manual-a" },
+        externalWriteAuthority: false,
+        valueMovingAuthority: false,
+      },
+      semanticDecisionAuthority: false,
+      certificateAuthority: false,
+      executionAuthority: true,
+      researchRunDispatchAuthorityConsumed: true,
+      providerOrModelWorkMayStart: true,
+      tradingExecutionAuthority: false,
+      liveExecutionEnabled: false,
+    });
+    expect(registry.snapshot().runs).toHaveLength(1);
+    expect(registry.snapshot().runAnnotations).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        runId: createdBody.run.runId,
+        category: "MANUAL_PREVIEW_BINDING",
+        sourceRecordRef: `manual-preview:${firstPreview.binding.previewRef}`,
+      }),
+    ]));
+
+    const reused = await fetch(`${baseUrl}/api/v1/agent-tasks/${task.taskId}/runs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        mode: "EXECUTE",
+        executionProfileId: profile.executionProfileId,
+        previewRef: firstPreview.binding.previewRef,
+        authorizationRef: "operator:manual-a",
+      }),
+    });
+    expect(reused.status).toBe(200);
+    await expect(reused.json()).resolves.toMatchObject({
+      ok: true,
+      reused: true,
+      run: { runId: createdBody.run.runId },
+      previewRef: firstPreview.binding.previewRef,
+      dispatchStartedByRequest: false,
+      runCreatedByRequest: false,
+      executionAuthority: false,
+      researchRunDispatchAuthorityConsumed: false,
+      providerOrModelWorkMayStart: false,
+      tradingExecutionAuthority: false,
+      liveExecutionEnabled: false,
+    });
+    expect(registry.snapshot().runs).toHaveLength(1);
+    expect(registry.snapshot().modelInvocations).toHaveLength(0);
+
+    const secondPreview = await fetch(`${baseUrl}/api/v1/agent-tasks/${task.taskId}/runs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        mode: "PREVIEW",
+        executionProfileId: profile.executionProfileId,
+      }),
+    }).then((response) => response.json()) as {
+      binding: { previewRef: string; nextRunOrdinal: number };
+    };
+    expect(secondPreview.binding.nextRunOrdinal).toBe(2);
+    expect(secondPreview.binding.previewRef).not.toBe(firstPreview.binding.previewRef);
+
+    const mismatchedRetry = await fetch(
+      `${baseUrl}/api/v1/agent-tasks/${task.taskId}/runs`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          mode: "EXECUTE",
+          executionProfileId: profile.executionProfileId,
+          previewRef: secondPreview.binding.previewRef,
+          authorizationRef: "operator:manual-a",
+        }),
+      },
+    );
+    expect(mismatchedRetry.status).toBe(409);
+    await expect(mismatchedRetry.json()).resolves.toMatchObject({
+      ok: false,
+      diagnostic: "manual authorizationRef is not bound to the requested previewRef",
+      researchRunDispatchAuthorityConsumed: false,
+      providerOrModelWorkMayStart: false,
+      tradingExecutionAuthority: false,
+    });
+    expect(registry.snapshot().runs).toHaveLength(1);
+
+    const stale = await fetch(`${baseUrl}/api/v1/agent-tasks/${task.taskId}/runs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        mode: "EXECUTE",
+        executionProfileId: profile.executionProfileId,
+        previewRef: firstPreview.binding.previewRef,
+        authorizationRef: "operator:manual-b",
+      }),
+    });
+    expect(stale.status).toBe(409);
+    await expect(stale.json()).resolves.toMatchObject({
+      ok: false,
+      diagnostic: "manual Agent run previewRef is stale or mismatched",
+      executionAuthority: false,
+      liveExecutionEnabled: false,
+    });
+    expect(registry.snapshot().runs).toHaveLength(1);
+
+    const otherPreview = await fetch(`${baseUrl}/api/v1/agent-tasks/${other.taskId}/runs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        mode: "PREVIEW",
+        executionProfileId: profile.executionProfileId,
+      }),
+    }).then((response) => response.json()) as { binding: { previewRef: string } };
+    const crossBound = await fetch(`${baseUrl}/api/v1/agent-tasks/${other.taskId}/runs`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        mode: "EXECUTE",
+        executionProfileId: profile.executionProfileId,
+        previewRef: otherPreview.binding.previewRef,
+        authorizationRef: "operator:manual-a",
+      }),
+    });
+    expect(crossBound.status).toBe(409);
+    await expect(crossBound.json()).resolves.toMatchObject({
+      ok: false,
+      diagnostic:
+        "manual authorizationRef is already bound to another task or execution profile",
+    });
+    expect(registry.snapshot().runs).toHaveLength(1);
+    expect(registry.snapshot().runs[0]?.runId).toBe(createdBody.run.runId);
+  });
+
+  it("inspects one Agent run without leaking another run's records", async () => {
+    const registry = new AgentExecutionRegistry();
+    const retained = buildAgentTask({
+      kind: "RULE_EVIDENCE_CLAIM",
+      protocol: "RULE_EVIDENCE_TASK_V1",
+      inputArtifacts: [],
+      taskPayload: { fixture: "operator-run-inspect" },
+      requestedEffectProtocol: "RULE_EVIDENCE_TOOLS_V1",
+      provenanceRef: "fixture:operator-run-inspect",
+      priority: 1,
+      createdAt: "2026-08-20T13:00:00.000Z",
+    });
+    const other = buildAgentTask({
+      kind: "RULE_EVIDENCE_CLAIM",
+      protocol: "RULE_EVIDENCE_TASK_V1",
+      inputArtifacts: [],
+      taskPayload: { fixture: "operator-run-other" },
+      requestedEffectProtocol: "RULE_EVIDENCE_TOOLS_V1",
+      provenanceRef: "fixture:operator-run-other",
+      priority: 2,
+      createdAt: "2026-08-20T13:01:00.000Z",
+    });
+    registry.saveBatch({ tasks: [retained, other] });
+    const { baseUrl } = await listenControlPlane({ agentExecutionRegistry: registry });
+    const profile = registry.snapshot().executionProfiles.find((item) =>
+      item.profileKey === "rule-evidence-codex-app-server"
+    )!;
+    const retainedRun = completeAgentRun(
+      buildAgentRun({
+        task: retained,
+        executionProfile: profile,
+        runOrdinal: 1,
+        authorization: {
+          kind: "MANUAL",
+          authorizationRef: "operator:run-inspect",
+          authorizedAt: "2026-08-20T13:02:00.000Z",
+        },
+        createdAt: "2026-08-20T13:02:00.000Z",
+      }),
+      "FAILED",
+      "2026-08-20T13:03:00.000Z",
+      "inspect fixture",
+    );
+    const otherRun = completeAgentRun(
+      buildAgentRun({
+        task: other,
+        executionProfile: profile,
+        runOrdinal: 1,
+        authorization: {
+          kind: "MANUAL",
+          authorizationRef: "operator:run-other",
+          authorizedAt: "2026-08-20T13:04:00.000Z",
+        },
+        createdAt: "2026-08-20T13:04:00.000Z",
+      }),
+      "FAILED",
+      "2026-08-20T13:05:00.000Z",
+      "must not leak",
+    );
+    registry.saveBatch({ runs: [retainedRun, otherRun] });
+
+    const missingId = `sha256:${"b".repeat(64)}`;
+    const missing = await fetch(`${baseUrl}/api/v1/agent-operator/runs/${missingId}`);
+    expect(missing.status).toBe(404);
+    await expect(missing.json()).resolves.toMatchObject({
+      ok: false,
+      diagnostic: `Agent run ${missingId} was not found`,
+      providerRequestsStartedByRead: 0,
+      modelInvocationsStartedByRead: 0,
+      writesStartedByRead: 0,
+      runsCreatedByRead: 0,
+      semanticDecisionAuthority: false,
+      certificateAuthority: false,
+      executionAuthority: false,
+      liveExecutionEnabled: false,
+    });
+
+    const response = await fetch(
+      `${baseUrl}/api/v1/agent-operator/runs/${retainedRun.runId}`,
+    );
+    expect(response.status).toBe(200);
+    const text = await response.text();
+    expect(Buffer.byteLength(text)).toBeLessThan(16_000);
+    const body = JSON.parse(text) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      schemaVersion: "pmh.agent-operator-run.v1",
+      run: { runId: retainedRun.runId, taskId: retained.taskId },
+      task: {
+        taskId: retained.taskId,
+        kind: "RULE_EVIDENCE_CLAIM",
+        taskPayloadHash: retained.taskPayloadHash,
+      },
+      executionProfile: {
+        executionProfileId: profile.executionProfileId,
+        profileKey: "rule-evidence-codex-app-server",
+      },
+      modelInvocationCount: 0,
+      modelInvocationsTruncated: false,
+      toolEffectCount: 0,
+      artifactCount: 0,
+      annotationCount: 0,
+      resultSelectionCount: 0,
+      providerRequestsStartedByRead: 0,
+      modelInvocationsStartedByRead: 0,
+      writesStartedByRead: 0,
+      runsCreatedByRead: 0,
+      automaticDispatch: false,
+      semanticDecisionAuthority: false,
+      certificateAuthority: false,
+      executionAuthority: false,
+      externalWriteAuthority: false,
+      valueMovingAuthority: false,
+      liveExecutionEnabled: false,
+    });
+    expect(text).not.toContain(otherRun.runId);
+    expect(body).not.toHaveProperty("execution");
+    expect(body).not.toHaveProperty("worldStateMechanisms");
   });
 
   it("allows incremented loopback Studio origins without reflecting remote origins", async () => {

--- a/plans/external-agent-operator-surface.md
+++ b/plans/external-agent-operator-surface.md
@@ -72,12 +72,22 @@ qualification, or verification verdict logic.
   historical tasks do not emit invalid actions. Manual preview binds both
   identities while proving zero provider/model/write/run effects and grants no
   execute authority.
+- A content-addressed preview now binds task payload, execution-profile
+  revision, next run ordinal, and run budget. Manual execution requires that
+  exact binding plus a caller-owned global idempotency reference.
+- First execution truthfully reports that research provider/model work may
+  start. An exact retry returns the retained run without duplicate dispatch;
+  cross-binding authorization reuse and stale previews fail closed.
+- Exact run inspection exposes only bounded run-bound records and zero read
+  effects. The CLI rejects identity drift, authority leakage, response-storage
+  leakage, unbounded collections, and inconsistent count/truncation metadata.
+- Studio uses the same preview binding and a preview-derived idempotency key;
+  the old global fixed browser authorization reference has been removed.
 
 ## Next implementation frontier
 
-The machine surface can now discover, inspect, and preview exact work but cannot
-yet execute and follow a research run to a retained outcome. The next mainline
-slice should require a caller-supplied authorization/idempotency reference,
-execute only a previously previewed task/profile binding, expose bounded run
-inspection and wait/resume commands, and test the whole journey with a fresh
-external Agent session under an explicit context budget.
+The machine surface can now discover, inspect, preview, execute, and poll an
+exact research run without gaining trading authority. The next mainline slice
+should add a bounded wait/resume contract for interrupted work, retain machine
+operator-friction measurements, and test the complete zero-context journey
+with a fresh external Agent session under an explicit context budget.


### PR DESCRIPTION
## Outcome

Completes the external-Agent machine journey from exact preview through idempotent research dispatch and bounded run inspection.

## Contract

- content-addresses task payload, execution-profile revision, run ordinal, and budget in a manual-run preview binding
- requires the exact preview plus a caller-owned global authorization/idempotency ref before dispatch
- returns one retained run on retry and rejects stale previews or cross-binding authorization reuse
- exposes bounded exact run inspection with literal-zero read effects
- keeps trading, external-write, value-moving, and live-execution authority false
- updates Studio to execute the reviewed binding instead of a global fixed authorization ref
- documents the complete CLI journey and next wait/resume frontier

## Verification

- `pnpm check`
- `pnpm test`
- `pnpm --filter @pmh/studio build`
- control-plane: 800 tests
- CLI: 31 tests
- Studio: 30 tests

Grok Build topic session `61394efb-bf73-45af-aac2-a995c46d2585` supplied atomic backend/CLI candidate diffs. Codex reviewed authority semantics, fixed persisted preview idempotency and Studio integration, and treated Git diff plus tests as the acceptance boundary.