### PR TITLE
External Agent: bounded run wait without fake resume

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -25,9 +25,11 @@ operator Agent as separate first-class layers. The first mainline slice makes
 workspace, and preserves stable recovery diagnostics without copying
 control-plane verdict logic. Exact target/task inspection now leads through a
 content-addressed zero-effect preview into idempotent research execution and
-bounded exact run inspection. The next slice is wait/resume plus measured
-zero-context qualification: time, retries, payload and context to the first
-retained outcome.
+bounded exact run inspection and a process-owned bounded wait. The system does
+not claim it can resume an `INTERRUPTED` run: that would require a new substrate
+and adapter session state machine. The next slice is measured zero-context
+qualification: time, retries, payload and context to the first retained
+outcome.
 
 The product brand is **Auto Prediction**, paired conceptually with Auto Quant.
 The rename is presentation-only for now: `pmh` CLI, package scopes, environment

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -27,6 +27,7 @@ pnpm --silent pmh agent task inspect <task-id>
 pnpm --silent pmh agent task preview <task-id> <execution-profile-id>
 pnpm --silent pmh agent task execute <task-id> <execution-profile-id> <preview-ref> <authorization-ref>
 pnpm --silent pmh agent run inspect <run-id>
+pnpm --silent pmh agent run wait <run-id> [wait-ms]
 pnpm --silent pmh venue list
 pnpm --silent pmh venue inspect <venue-id>
 ```
@@ -61,9 +62,16 @@ fails closed. Every response keeps trading, external-write, value-moving, and
 live-execution authority literal `false`.
 
 `agent run inspect` returns one exact run plus bounded, run-bound invocation,
-tool-effect, artifact, annotation, and result-selection collections. A prepared
-run advertises the same inspect command for polling; a terminal run points back
-to its task and workspace. This makes the current machine journey:
+tool-effect, artifact, annotation, and result-selection collections. A terminal
+run points back to its task and workspace.
+
+`agent run wait` avoids a client-side polling loop. It waits up to 30 seconds
+by default (configurable from 1 to 60,000 milliseconds and never beyond the run
+profile's wall-clock budget) on the already-authorized in-process run. It does
+not create, cancel, or redispatch work. `TIMEOUT` means the same run is still
+active; `NOT_AWAITABLE_IN_THIS_PROCESS` means the durable run exists but this
+process no longer owns its completion promise. This makes the current machine
+journey:
 
 ```text
 agent workspace
@@ -71,6 +79,7 @@ agent workspace
   -> agent task inspect <exact-task-id>
   -> agent task preview <exact-task-id> <exact-profile-id>
   -> agent task execute <exact-task-id> <exact-profile-id> <preview-ref> external-agent:<preview-ref>
+  -> agent run wait <exact-run-id>
   -> agent run inspect <exact-run-id>
 ```
 
@@ -94,8 +103,15 @@ Agents should follow that field rather than guessing a route.
 
 Unknown commands and venue identities fail closed with a non-zero process exit code and a JSON diagnostic. The present CLI cannot write external state or move value; both effects are literal `false` in every response.
 
-Run wait/resume, campaign control,
+True runtime resume, campaign control,
 catalog refresh, claim/link inspection, opportunity verification,
 deterministic replay, shadow execution, and Core projections remain planned CLI
 surfaces. Human-readable Studio views and compact CLI views consume
 control-plane projections and must never recompute verdicts.
+
+There is deliberately no `agent run resume` command. `INTERRUPTED` is a
+terminal retained attempt and a restarted process cannot honestly restore the
+lost runtime session today. Retrying requires a new task preview, a new
+`previewRef`, and a new authorization reference, producing a higher run
+ordinal. Reusing the interrupted run's old authorization reference only returns
+that same retained run and never silently redispatches it.

--- a/packages/cli/src/dispatch.ts
+++ b/packages/cli/src/dispatch.ts
@@ -16,6 +16,7 @@ export const SUPPORTED_COMMANDS = Object.freeze([
   "agent task preview <task-id> <execution-profile-id>",
   "agent task execute <task-id> <execution-profile-id> <preview-ref> <authorization-ref>",
   "agent run inspect <run-id>",
+  "agent run wait <run-id> [wait-ms]",
   "venue list",
   "venue inspect <venue-id>",
 ] as const);
@@ -73,6 +74,12 @@ const COMMAND_CATALOG = Object.freeze([
     command: "agent run inspect <run-id>",
     kind: "CONTROL_PLANE_READ",
     description: "Inspect one Agent run and only the records bound to that run.",
+    requiresControlPlane: true,
+  }),
+  Object.freeze({
+    command: "agent run wait <run-id> [wait-ms]",
+    kind: "CONTROL_PLANE_READ",
+    description: "Wait up to 60 seconds for one in-process research run without polling.",
     requiresControlPlane: true,
   }),
   Object.freeze({
@@ -142,6 +149,21 @@ function invalidAuthorizationEnvelope(
       message: "authorization-ref must be a bounded nonblank identifier.",
     }],
     allowedNextActions: ["agent workspace", "help"],
+    ok: false,
+  });
+}
+
+function invalidWaitEnvelope(args: readonly string[]): CliEnvelope {
+  return createCliEnvelope({
+    command: "agent.run.wait",
+    arguments: args,
+    state: null,
+    diagnostics: [{
+      severity: "ERROR",
+      code: "CLI_ARGUMENT_INVALID",
+      message: "wait-ms must be an integer from 1 to 60000.",
+    }],
+    allowedNextActions: ["agent run inspect <run-id>", "help"],
     ok: false,
   });
 }
@@ -542,14 +564,18 @@ function runBoundCollection(
   });
 }
 
-function validateAgentOperatorRun(value: unknown, runId: string) {
+function validateAgentOperatorRun(
+  value: unknown,
+  runId: string,
+  schemaVersion = "pmh.agent-operator-run.v1",
+) {
   const document = objectValue(value);
   const run = objectValue(document?.run);
   const task = objectValue(document?.task);
   const executionProfile = objectValue(document?.executionProfile);
   const status = stringValue(run?.status);
   if (
-    document?.schemaVersion !== "pmh.agent-operator-run.v1" ||
+    document?.schemaVersion !== schemaVersion ||
     run?.schemaVersion !== "pmh.agent-run.v1" ||
     run.runId !== runId ||
     run.externalWriteAuthority !== false ||
@@ -592,6 +618,43 @@ function validateAgentOperatorRun(value: unknown, runId: string) {
     taskId: run.taskId,
     status,
   });
+}
+
+function validateAgentOperatorRunWait(
+  value: unknown,
+  runId: string,
+  waitMs: number,
+) {
+  const inspected = validateAgentOperatorRun(
+    value,
+    runId,
+    "pmh.agent-operator-run-wait.v1",
+  );
+  if (inspected === null) return null;
+  const document = inspected.document;
+  const waitOutcome = stringValue(document.waitOutcome);
+  const waitedMs = numberValue(document.waitedMs);
+  if (
+    document.waitMs !== waitMs ||
+    waitedMs === null ||
+    waitedMs < 0 ||
+    waitOutcome === null ||
+    !["COMPLETED", "TIMEOUT", "ALREADY_TERMINAL",
+      "NOT_AWAITABLE_IN_THIS_PROCESS"].includes(waitOutcome) ||
+    document.researchRunDispatchAuthorityConsumed !== false ||
+    document.providerOrModelWorkMayStart !== false ||
+    (waitOutcome === "COMPLETED" && (
+      document.awaitedInProcess !== true || inspected.status === "PREPARED"
+    )) ||
+    (waitOutcome === "TIMEOUT" && (
+      document.awaitedInProcess !== true || inspected.status !== "PREPARED"
+    )) ||
+    (["ALREADY_TERMINAL", "NOT_AWAITABLE_IN_THIS_PROCESS"].includes(waitOutcome) &&
+      document.awaitedInProcess !== false) ||
+    (waitOutcome === "ALREADY_TERMINAL" && inspected.status === "PREPARED") ||
+    (waitOutcome === "NOT_AWAITABLE_IN_THIS_PROCESS" && inspected.status !== "PREPARED")
+  ) return null;
+  return Object.freeze({ ...inspected, waitOutcome, waitedMs });
 }
 
 function validateAgentOperatorWorkspace(value: unknown) {
@@ -1021,6 +1084,7 @@ export async function runCli(
           controlPlaneUrl: result.baseUrl,
         }),
         allowedNextActions: Object.freeze([
+          `agent run wait ${executed.runId}`,
           `agent run inspect ${executed.runId}`,
           "agent workspace",
           "help",
@@ -1058,7 +1122,7 @@ export async function runCli(
           controlPlaneUrl: result.baseUrl,
         }),
         allowedNextActions: inspected.status === "PREPARED"
-          ? Object.freeze([`agent run inspect ${runId}`])
+          ? Object.freeze([`agent run wait ${runId}`, `agent run inspect ${runId}`])
           : Object.freeze([
               `agent task inspect ${inspected.taskId}`,
               "agent workspace",
@@ -1068,6 +1132,57 @@ export async function runCli(
       });
     } catch (error) {
       return controlPlaneFailure("agent.run.inspect", error, [runId]);
+    }
+  }
+
+  if (
+    namespace === "agent" &&
+    action === "run" &&
+    venueId === "wait" &&
+    (extra.length === 1 || extra.length === 2) &&
+    extra[0] !== undefined
+  ) {
+    const runId = extra[0];
+    const args = [...extra];
+    if (!hashValue(runId)) {
+      return invalidIdentityEnvelope("agent.run.wait", args, "run-id");
+    }
+    const waitMsText = extra[1] ?? "30000";
+    const waitMs = /^[1-9][0-9]*$/u.test(waitMsText) ? Number(waitMsText) : Number.NaN;
+    if (!Number.isSafeInteger(waitMs) || waitMs < 1 || waitMs > 60_000) {
+      return invalidWaitEnvelope(args);
+    }
+    const path = `/api/v1/agent-operator/runs/${runId}/wait?waitMs=${waitMs}` as `/${string}`;
+    try {
+      const result = await requestControlPlaneJson(path, {
+        ...options,
+        timeoutMs: Math.max(options.timeoutMs ?? 30_000, waitMs + 2_000),
+      });
+      const waited = validateAgentOperatorRunWait(result.value, runId, waitMs);
+      if (waited === null) {
+        return malformedControlPlaneEnvelope("agent.run.wait", path, args);
+      }
+      const allowedNextActions = waited.status === "PREPARED"
+        ? waited.waitOutcome === "TIMEOUT"
+          ? Object.freeze([`agent run wait ${runId} ${waitMs}`, `agent run inspect ${runId}`])
+          : Object.freeze([`agent run inspect ${runId}`])
+        : Object.freeze([
+            `agent task inspect ${waited.taskId}`,
+            "agent workspace",
+            "help",
+          ]);
+      return createCliEnvelope({
+        command: "agent.run.wait",
+        arguments: args,
+        state: Object.freeze({
+          ...waited.document,
+          controlPlaneUrl: result.baseUrl,
+        }),
+        allowedNextActions,
+        ok: true,
+      });
+    } catch (error) {
+      return controlPlaneFailure("agent.run.wait", error, args);
     }
   }
 

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -250,9 +250,14 @@ function executeDocument(input: {
   };
 }
 
-function operatorRun(runId: string, status = "PREPARED", leakedRunId?: string) {
+function operatorRun(
+  runId: string,
+  status = "PREPARED",
+  leakedRunId?: string,
+  schemaVersion = "pmh.agent-operator-run.v1",
+) {
   return {
-    schemaVersion: "pmh.agent-operator-run.v1",
+    schemaVersion,
     run: manualRun(runId, TASK_ID, PROFILE_ID, status),
     task: {
       taskId: TASK_ID,
@@ -288,6 +293,24 @@ function operatorRun(runId: string, status = "PREPARED", leakedRunId?: string) {
   };
 }
 
+function operatorRunWait(
+  runId: string,
+  status: string,
+  waitMs: number,
+  waitOutcome: "COMPLETED" | "TIMEOUT" | "ALREADY_TERMINAL" |
+    "NOT_AWAITABLE_IN_THIS_PROCESS",
+) {
+  return {
+    ...operatorRun(runId, status, undefined, "pmh.agent-operator-run-wait.v1"),
+    waitMs,
+    waitedMs: waitOutcome === "ALREADY_TERMINAL" ? 0 : waitMs,
+    waitOutcome,
+    awaitedInProcess: waitOutcome === "COMPLETED" || waitOutcome === "TIMEOUT",
+    researchRunDispatchAuthorityConsumed: false,
+    providerOrModelWorkMayStart: false,
+  };
+}
+
 describe("versioned CLI envelope", () => {
   it("discovers the exact command surface without a running control plane", async () => {
     const result = await runCli([]);
@@ -308,6 +331,7 @@ describe("versioned CLI envelope", () => {
       "agent task execute <task-id> <execution-profile-id> <preview-ref> <authorization-ref>",
     );
     expect(result.allowedNextActions).toContain("agent run inspect <run-id>");
+    expect(result.allowedNextActions).toContain("agent run wait <run-id> [wait-ms]");
   });
 
   it("reports the system's Node 22 baseline and live-disabled boundary", async () => {
@@ -802,6 +826,7 @@ describe("versioned CLI envelope", () => {
       liveExecutionEnabled: false,
     });
     expect(result.allowedNextActions).toEqual([
+      `agent run wait ${RUN_ID}`,
       `agent run inspect ${RUN_ID}`,
       "agent workspace",
       "help",
@@ -838,7 +863,7 @@ describe("versioned CLI envelope", () => {
       providerOrModelWorkMayStart: false,
       tradingExecutionAuthority: false,
     });
-    expect(result.allowedNextActions[0]).toBe(`agent run inspect ${RUN_ID}`);
+    expect(result.allowedNextActions[0]).toBe(`agent run wait ${RUN_ID}`);
     expect(result.effects.liveExecutionEnabled).toBe(false);
   });
 
@@ -889,7 +914,10 @@ describe("versioned CLI envelope", () => {
       tradingExecutionAuthority: false,
       liveExecutionEnabled: false,
     });
-    expect(result.allowedNextActions).toEqual([`agent run inspect ${RUN_ID}`]);
+    expect(result.allowedNextActions).toEqual([
+      `agent run wait ${RUN_ID}`,
+      `agent run inspect ${RUN_ID}`,
+    ]);
   });
 
   it("inspects a terminal run and returns exact task inspect next actions", async () => {
@@ -903,6 +931,71 @@ describe("versioned CLI envelope", () => {
       "agent workspace",
       "help",
     ]);
+  });
+
+  it("waits for a run with a bounded server-side wait and returns terminal actions", async () => {
+    const baseUrl = await serve((request, response) => {
+      expect(request.method).toBe("GET");
+      expect(request.url).toBe(
+        `/api/v1/agent-operator/runs/${RUN_ID}/wait?waitMs=1250`,
+      );
+      json(response, operatorRunWait(RUN_ID, "SUCCEEDED", 1250, "COMPLETED"));
+    });
+    const result = await runCli(
+      ["agent", "run", "wait", RUN_ID, "1250"],
+      { baseUrl },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.identity).toEqual({
+      command: "agent.run.wait",
+      arguments: [RUN_ID, "1250"],
+    });
+    expect(result.state).toMatchObject({
+      schemaVersion: "pmh.agent-operator-run-wait.v1",
+      run: { runId: RUN_ID, status: "SUCCEEDED" },
+      waitMs: 1250,
+      waitOutcome: "COMPLETED",
+      awaitedInProcess: true,
+      researchRunDispatchAuthorityConsumed: false,
+      providerOrModelWorkMayStart: false,
+      tradingExecutionAuthority: false,
+      liveExecutionEnabled: false,
+    });
+    expect(result.allowedNextActions).toEqual([
+      `agent task inspect ${TASK_ID}`,
+      "agent workspace",
+      "help",
+    ]);
+  });
+
+  it("returns an exact wait action after timeout but never fakes a detached wait", async () => {
+    const timeoutUrl = await serve((_request, response) =>
+      json(response, operatorRunWait(RUN_ID, "PREPARED", 250, "TIMEOUT"))
+    );
+    const timedOut = await runCli(
+      ["agent", "run", "wait", RUN_ID, "250"],
+      { baseUrl: timeoutUrl },
+    );
+    expect(timedOut.ok).toBe(true);
+    expect(timedOut.allowedNextActions).toEqual([
+      `agent run wait ${RUN_ID} 250`,
+      `agent run inspect ${RUN_ID}`,
+    ]);
+
+    const detachedUrl = await serve((_request, response) =>
+      json(response, operatorRunWait(
+        RUN_ID,
+        "PREPARED",
+        30_000,
+        "NOT_AWAITABLE_IN_THIS_PROCESS",
+      ))
+    );
+    const detached = await runCli(
+      ["agent", "run", "wait", RUN_ID],
+      { baseUrl: detachedUrl },
+    );
+    expect(detached.ok).toBe(true);
+    expect(detached.allowedNextActions).toEqual([`agent run inspect ${RUN_ID}`]);
   });
 
   it("rejects a run inspect that leaks another run's records", async () => {
@@ -943,6 +1036,14 @@ describe("versioned CLI envelope", () => {
     expect(badRun.diagnostics[0]).toMatchObject({
       code: "CLI_ARGUMENT_INVALID",
       message: "run-id must be an exact sha256 identity.",
+    });
+    const badWait = await runCli(
+      ["agent", "run", "wait", RUN_ID, "60001"],
+      host,
+    );
+    expect(badWait.diagnostics[0]).toMatchObject({
+      code: "CLI_ARGUMENT_INVALID",
+      message: "wait-ms must be an integer from 1 to 60000.",
     });
     expect(requested).toBe(false);
   });

--- a/packages/control-plane/src/agent-campaign-dispatcher.ts
+++ b/packages/control-plane/src/agent-campaign-dispatcher.ts
@@ -111,6 +111,21 @@ export type ManualAgentDispatchPreview = Readonly<{
   providerRequestsStarted: 0;
 }>;
 
+export type AgentRunWaitOutcome =
+  | "COMPLETED"
+  | "TIMEOUT"
+  | "ALREADY_TERMINAL"
+  | "NOT_AWAITABLE_IN_THIS_PROCESS";
+
+export type AgentRunWaitResult = Readonly<{
+  run: AgentRun;
+  waitOutcome: AgentRunWaitOutcome;
+  awaitedInProcess: boolean;
+}>;
+
+const MIN_RUN_WAIT_MS = 1;
+const MAX_RUN_WAIT_MS = 60_000;
+
 export type AgentCampaignDispatcherOptions = Readonly<{
   registry: AgentExecutionRegistry;
   credentialBroker: AgentCredentialBroker;
@@ -261,6 +276,59 @@ export class AgentCampaignDispatcher {
       () => this.#active.delete(run.runId),
     );
     return Object.freeze({ run, completion });
+  }
+
+  public async waitForRun(runId: Hash, waitMs: number): Promise<AgentRunWaitResult> {
+    if (!Number.isSafeInteger(waitMs) || waitMs < MIN_RUN_WAIT_MS || waitMs > MAX_RUN_WAIT_MS) {
+      throw new Error("waitMs must be a safe integer from 1 to 60000");
+    }
+    const retained = (): AgentRun => {
+      const run = this.#registry.snapshot().runs.find((item) => item.runId === runId);
+      if (run === undefined) throw new Error("Agent run is unavailable");
+      return run;
+    };
+    const current = retained();
+    if (current.status !== "PREPARED") {
+      return Object.freeze({
+        run: current,
+        waitOutcome: "ALREADY_TERMINAL" as const,
+        awaitedInProcess: false,
+      });
+    }
+    const waiter = this.#active.get(runId);
+    if (waiter === undefined) {
+      return Object.freeze({
+        run: current,
+        waitOutcome: "NOT_AWAITABLE_IN_THIS_PROCESS" as const,
+        awaitedInProcess: false,
+      });
+    }
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const timedOut = await Promise.race([
+        waiter.then(() => false, () => false),
+        new Promise<boolean>((resolve) => {
+          timer = setTimeout(() => resolve(true), waitMs);
+        }),
+      ]);
+      const run = retained();
+      if (timedOut && run.status === "PREPARED") {
+        return Object.freeze({
+          run,
+          waitOutcome: "TIMEOUT" as const,
+          awaitedInProcess: true,
+        });
+      }
+      return Object.freeze({
+        run,
+        waitOutcome: run.status === "PREPARED"
+          ? "TIMEOUT" as const
+          : "COMPLETED" as const,
+        awaitedInProcess: true,
+      });
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
   }
 
   public dispatchCampaign(campaignId: Hash): AgentCampaignDispatchResult {

--- a/packages/control-plane/src/server.ts
+++ b/packages/control-plane/src/server.ts
@@ -6566,6 +6566,92 @@ export function createControlPlane(options?: {
     });
   };
 
+  const agentOperatorReadEffects = Object.freeze({
+    providerRequestsStartedByRead: 0 as const,
+    modelInvocationsStartedByRead: 0 as const,
+    fetchesStartedByRead: 0 as const,
+    writesStartedByRead: 0 as const,
+    runsCreatedByRead: 0 as const,
+    automaticDispatch: false as const,
+    semanticDecisionAuthority: false as const,
+    certificateAuthority: false as const,
+    executionAuthority: false as const,
+    researchRunDispatchAuthorityConsumed: false as const,
+    providerOrModelWorkMayStart: false as const,
+    tradingExecutionAuthority: false as const,
+    externalWriteAuthority: false as const,
+    valueMovingAuthority: false as const,
+    liveExecutionEnabled: false as const,
+  });
+  const agentOperatorRunDocument = (runId: Hash, retainedRun?: AgentRun) => {
+    const snapshot = agentExecutionRegistry.snapshot();
+    const run = retainedRun ?? snapshot.runs.find((item) => item.runId === runId);
+    if (run === undefined) return null;
+    const task = snapshot.tasks.find((item) => item.taskId === run.taskId);
+    const profile = snapshot.executionProfiles.find((item) =>
+      item.executionProfileId === run.executionProfileId
+    );
+    const capCollection = <T,>(items: readonly T[], cap = 32) => Object.freeze({
+      items: Object.freeze(items.slice(0, cap)),
+      count: items.length,
+      truncated: items.length > cap,
+    });
+    const modelInvocations = capCollection(
+      snapshot.modelInvocations.filter((item) => item.runId === runId)
+        .sort((left, right) => left.ordinal - right.ordinal ||
+          left.invocationId.localeCompare(right.invocationId)),
+    );
+    const toolEffects = capCollection(
+      snapshot.toolEffects.filter((item) => item.runId === runId)
+        .sort((left, right) => left.ordinal - right.ordinal ||
+          left.effectId.localeCompare(right.effectId)),
+    );
+    const artifacts = capCollection(
+      snapshot.runArtifacts.filter((item) => item.runId === runId)
+        .sort((left, right) => left.ordinal - right.ordinal ||
+          left.artifactId.localeCompare(right.artifactId)),
+    );
+    const annotations = capCollection(
+      snapshot.runAnnotations.filter((item) => item.runId === runId)
+        .sort((left, right) => left.createdAt.localeCompare(right.createdAt) ||
+          left.annotationId.localeCompare(right.annotationId)),
+    );
+    const resultSelections = capCollection(
+      snapshot.resultSelections.filter((item) => item.runId === runId)
+        .sort((left, right) => left.selectedAt.localeCompare(right.selectedAt) ||
+          left.selectionId.localeCompare(right.selectionId)),
+    );
+    return Object.freeze({
+      run,
+      task: task === undefined ? null : Object.freeze({
+        taskId: task.taskId,
+        kind: task.kind,
+        taskPayloadHash: task.taskPayloadHash,
+        protocol: task.protocol,
+      }),
+      executionProfile: profile === undefined ? null : Object.freeze({
+        executionProfileId: profile.executionProfileId,
+        profileKey: profile.profileKey,
+        revision: profile.revision,
+      }),
+      modelInvocations: modelInvocations.items,
+      modelInvocationCount: modelInvocations.count,
+      modelInvocationsTruncated: modelInvocations.truncated,
+      toolEffects: toolEffects.items,
+      toolEffectCount: toolEffects.count,
+      toolEffectsTruncated: toolEffects.truncated,
+      artifacts: artifacts.items,
+      artifactCount: artifacts.count,
+      artifactsTruncated: artifacts.truncated,
+      annotations: annotations.items,
+      annotationCount: annotations.count,
+      annotationsTruncated: annotations.truncated,
+      resultSelections: resultSelections.items,
+      resultSelectionCount: resultSelections.count,
+      resultSelectionsTruncated: resultSelections.truncated,
+    });
+  };
+
   const handleRequest = async (
     request: IncomingMessage,
     response: ServerResponse,
@@ -6863,111 +6949,67 @@ export function createControlPlane(options?: {
       }), { "cache-control": "no-store" });
       return;
     }
+    const operatorRunWaitMatch = url.pathname.match(
+      /^\/api\/v1\/agent-operator\/runs\/(sha256:[0-9a-f]{64})\/wait$/u,
+    );
+    if (request.method === "GET" && operatorRunWaitMatch !== null) {
+      await ready;
+      const runId = operatorRunWaitMatch[1] as Hash;
+      const waitMsText = url.searchParams.get("waitMs");
+      const waitMs = waitMsText === null || !/^[1-9][0-9]*$/u.test(waitMsText)
+        ? Number.NaN
+        : Number(waitMsText);
+      const startedAt = performance.now();
+      try {
+        const snapshot = agentExecutionRegistry.snapshot();
+        const retained = snapshot.runs.find((item) => item.runId === runId);
+        const profile = retained === undefined ? undefined : snapshot.executionProfiles.find(
+          (item) => item.executionProfileId === retained.executionProfileId,
+        );
+        if (profile !== undefined && waitMs > profile.runBudget.maximumWallClockMs) {
+          throw new Error("waitMs exceeds the run execution profile wall-clock budget");
+        }
+        const waited = await agentCampaignDispatcher.waitForRun(runId, waitMs);
+        const document = agentOperatorRunDocument(runId, waited.run);
+        if (document === null) throw new Error("Agent run is unavailable");
+        writeJson(response, 200, Object.freeze({
+          schemaVersion: "pmh.agent-operator-run-wait.v1" as const,
+          ...document,
+          waitMs,
+          waitedMs: Math.max(0, Math.round(performance.now() - startedAt)),
+          waitOutcome: waited.waitOutcome,
+          awaitedInProcess: waited.awaitedInProcess,
+          ...agentOperatorReadEffects,
+        }), { "cache-control": "no-store" });
+      } catch (error) {
+        const missing = agentOperatorRunDocument(runId) === null;
+        writeJson(response, missing ? 404 : 409, Object.freeze({
+          ok: false as const,
+          diagnostic: error instanceof Error ? error.message : "Agent run wait failed",
+          ...agentOperatorReadEffects,
+        }), { "cache-control": "no-store" });
+      }
+      return;
+    }
     const operatorRunMatch = url.pathname.match(
       /^\/api\/v1\/agent-operator\/runs\/(sha256:[0-9a-f]{64})$/u,
     );
     if (request.method === "GET" && operatorRunMatch !== null) {
       await ready;
-      const snapshot = agentExecutionRegistry.snapshot();
       const runId = operatorRunMatch[1] as Hash;
-      const run = snapshot.runs.find((item) => item.runId === runId);
-      const operatorReadEffects = Object.freeze({
-        providerRequestsStartedByRead: 0 as const,
-        modelInvocationsStartedByRead: 0 as const,
-        fetchesStartedByRead: 0 as const,
-        writesStartedByRead: 0 as const,
-        runsCreatedByRead: 0 as const,
-        automaticDispatch: false as const,
-        semanticDecisionAuthority: false as const,
-        certificateAuthority: false as const,
-        executionAuthority: false as const,
-        externalWriteAuthority: false as const,
-        valueMovingAuthority: false as const,
-        liveExecutionEnabled: false as const,
-      });
-      if (run === undefined) {
+      const document = agentOperatorRunDocument(runId);
+      if (document === null) {
         writeJson(response, 404, Object.freeze({
           ok: false as const,
           diagnostic: `Agent run ${runId} was not found`,
-          ...operatorReadEffects,
+          ...agentOperatorReadEffects,
         }), { "cache-control": "no-store" });
         return;
       }
-      const task = snapshot.tasks.find((item) => item.taskId === run.taskId);
-      const profile = snapshot.executionProfiles.find((item) =>
-        item.executionProfileId === run.executionProfileId
-      );
-      const capCollection = <T,>(
-        items: readonly T[],
-        cap = 32,
-      ): Readonly<{
-        items: readonly T[];
-        count: number;
-        truncated: boolean;
-      }> => Object.freeze({
-        items: Object.freeze(items.slice(0, cap)),
-        count: items.length,
-        truncated: items.length > cap,
-      });
-      const modelInvocations = capCollection(
-        snapshot.modelInvocations.filter((item) => item.runId === runId)
-          .sort((left, right) => left.ordinal - right.ordinal ||
-            left.invocationId.localeCompare(right.invocationId)),
-      );
-      const toolEffects = capCollection(
-        snapshot.toolEffects.filter((item) => item.runId === runId)
-          .sort((left, right) => left.ordinal - right.ordinal ||
-            left.effectId.localeCompare(right.effectId)),
-      );
-      const artifacts = capCollection(
-        snapshot.runArtifacts.filter((item) => item.runId === runId)
-          .sort((left, right) => left.ordinal - right.ordinal ||
-            left.artifactId.localeCompare(right.artifactId)),
-      );
-      const annotations = capCollection(
-        snapshot.runAnnotations.filter((item) => item.runId === runId)
-          .sort((left, right) => left.createdAt.localeCompare(right.createdAt) ||
-            left.annotationId.localeCompare(right.annotationId)),
-      );
-      const resultSelections = capCollection(
-        snapshot.resultSelections.filter((item) => item.runId === runId)
-          .sort((left, right) => left.selectedAt.localeCompare(right.selectedAt) ||
-            left.selectionId.localeCompare(right.selectionId)),
-      );
       writeJson(response, 200, Object.freeze({
         schemaVersion: "pmh.agent-operator-run.v1" as const,
-        run,
-        task: task === undefined
-          ? null
-          : Object.freeze({
-              taskId: task.taskId,
-              kind: task.kind,
-              taskPayloadHash: task.taskPayloadHash,
-              protocol: task.protocol,
-            }),
-        executionProfile: profile === undefined
-          ? null
-          : Object.freeze({
-              executionProfileId: profile.executionProfileId,
-              profileKey: profile.profileKey,
-              revision: profile.revision,
-            }),
-        modelInvocations: modelInvocations.items,
-        modelInvocationCount: modelInvocations.count,
-        modelInvocationsTruncated: modelInvocations.truncated,
-        toolEffects: toolEffects.items,
-        toolEffectCount: toolEffects.count,
-        toolEffectsTruncated: toolEffects.truncated,
-        artifacts: artifacts.items,
-        artifactCount: artifacts.count,
-        artifactsTruncated: artifacts.truncated,
-        annotations: annotations.items,
-        annotationCount: annotations.count,
-        annotationsTruncated: annotations.truncated,
-        resultSelections: resultSelections.items,
-        resultSelectionCount: resultSelections.count,
-        resultSelectionsTruncated: resultSelections.truncated,
-        ...operatorReadEffects,
+        ...document,
+        ...agentOperatorReadEffects,
       }), { "cache-control": "no-store" });
       return;
     }

--- a/packages/control-plane/test/agent-campaign-dispatcher.test.ts
+++ b/packages/control-plane/test/agent-campaign-dispatcher.test.ts
@@ -71,7 +71,8 @@ function fixture(taskCount: number, budget?: Partial<{
   intervalMs: number;
 } = { kind: "MANUAL_ONLY", intervalMs: null }, taskRunPolicy?:
   "REPEATABLE" | "ONCE_PER_TASK_PER_LINEAGE", onExecutionResult?:
-  ConstructorParameters<typeof AgentCampaignDispatcher>[0]["onExecutionResult"]) {
+  ConstructorParameters<typeof AgentCampaignDispatcher>[0]["onExecutionResult"],
+  beforeAdvance?: () => Promise<void>) {
   const time = clock();
   const store = new SqliteOperationalStore(":memory:");
   const registry = new AgentExecutionRegistry(store);
@@ -125,6 +126,7 @@ function fixture(taskCount: number, budget?: Partial<{
     _context: AgentRuntimeOpenContext,
   ) => ({
     advance: async () => {
+      await beforeAdvance?.();
       const startedAt = time.iso();
       time.advance(10);
       return Object.freeze({
@@ -445,6 +447,95 @@ describe("Agent campaign dispatcher", () => {
       sourceRecordRef: `fixture-revision:${work.taskId}`,
       createdAt: dispatched.run.createdAt,
     }]);
+    item.store.close();
+  });
+
+  it("waits on an active manual run without creating or redispatching work", async () => {
+    const item = fixture(1);
+    const work = item.tasks[0]!.task;
+    const profile = item.registry.snapshot().executionProfiles[0]!;
+    const dispatched = item.dispatcher.dispatchManual(
+      work.taskId,
+      profile.executionProfileId,
+      "operator:wait-completion",
+    );
+
+    await expect(item.dispatcher.waitForRun(dispatched.run.runId, 1_000)).resolves
+      .toMatchObject({
+        run: { runId: dispatched.run.runId, status: "SUCCEEDED" },
+        waitOutcome: "COMPLETED",
+        awaitedInProcess: true,
+      });
+    expect(item.registry.snapshot().runs).toHaveLength(1);
+    expect(item.registry.snapshot().modelInvocations).toHaveLength(1);
+    item.store.close();
+  });
+
+  it("times out without cancelling an active run and later observes its completion", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const item = fixture(
+      1,
+      undefined,
+      { kind: "MANUAL_ONLY", intervalMs: null },
+      undefined,
+      undefined,
+      () => gate,
+    );
+    const work = item.tasks[0]!.task;
+    const profile = item.registry.snapshot().executionProfiles[0]!;
+    const dispatched = item.dispatcher.dispatchManual(
+      work.taskId,
+      profile.executionProfileId,
+      "operator:wait-timeout",
+    );
+
+    await expect(item.dispatcher.waitForRun(dispatched.run.runId, 1)).resolves
+      .toMatchObject({
+        run: { status: "PREPARED" },
+        waitOutcome: "TIMEOUT",
+        awaitedInProcess: true,
+      });
+    expect(item.registry.snapshot().runs).toHaveLength(1);
+    release();
+    await dispatched.completion;
+    await expect(item.dispatcher.waitForRun(dispatched.run.runId, 1)).resolves
+      .toMatchObject({
+        run: { status: "SUCCEEDED" },
+        waitOutcome: "ALREADY_TERMINAL",
+        awaitedInProcess: false,
+      });
+    item.store.close();
+  });
+
+  it("distinguishes a retained prepared run that this process cannot await", async () => {
+    const item = fixture(1);
+    const work = item.tasks[0]!.task;
+    const profile = item.registry.snapshot().executionProfiles[0]!;
+    const prepared = buildAgentRun({
+      task: work,
+      executionProfile: profile,
+      runOrdinal: 1,
+      authorization: {
+        kind: "MANUAL",
+        authorizationRef: "operator:detached-prepared",
+        authorizedAt: item.time.iso(),
+      },
+      createdAt: item.time.iso(),
+    });
+    item.registry.saveBatch({ runs: [prepared] });
+
+    await expect(item.dispatcher.waitForRun(prepared.runId, 100)).resolves.toMatchObject({
+      run: { runId: prepared.runId, status: "PREPARED" },
+      waitOutcome: "NOT_AWAITABLE_IN_THIS_PROCESS",
+      awaitedInProcess: false,
+    });
+    await expect(item.dispatcher.waitForRun(`sha256:${"0".repeat(64)}`, 100))
+      .rejects.toThrow(/unavailable/);
+    for (const waitMs of [0, 60_001, 1.5, Number.NaN]) {
+      await expect(item.dispatcher.waitForRun(prepared.runId, waitMs))
+        .rejects.toThrow(/safe integer from 1 to 60000/);
+    }
     item.store.close();
   });
 

--- a/packages/control-plane/test/server.test.ts
+++ b/packages/control-plane/test/server.test.ts
@@ -1221,6 +1221,51 @@ describe("control-plane HTTP surface", () => {
     expect(text).not.toContain(otherRun.runId);
     expect(body).not.toHaveProperty("execution");
     expect(body).not.toHaveProperty("worldStateMechanisms");
+
+    const waited = await fetch(
+      `${baseUrl}/api/v1/agent-operator/runs/${retainedRun.runId}/wait?waitMs=100`,
+    );
+    expect(waited.status).toBe(200);
+    await expect(waited.json()).resolves.toMatchObject({
+      schemaVersion: "pmh.agent-operator-run-wait.v1",
+      run: { runId: retainedRun.runId, status: "FAILED" },
+      waitMs: 100,
+      waitOutcome: "ALREADY_TERMINAL",
+      awaitedInProcess: false,
+      providerRequestsStartedByRead: 0,
+      modelInvocationsStartedByRead: 0,
+      writesStartedByRead: 0,
+      runsCreatedByRead: 0,
+      executionAuthority: false,
+      researchRunDispatchAuthorityConsumed: false,
+      providerOrModelWorkMayStart: false,
+      tradingExecutionAuthority: false,
+      externalWriteAuthority: false,
+      valueMovingAuthority: false,
+      liveExecutionEnabled: false,
+    });
+
+    const invalidWait = await fetch(
+      `${baseUrl}/api/v1/agent-operator/runs/${retainedRun.runId}/wait?waitMs=60001`,
+    );
+    expect(invalidWait.status).toBe(409);
+    await expect(invalidWait.json()).resolves.toMatchObject({
+      ok: false,
+      diagnostic: "waitMs must be a safe integer from 1 to 60000",
+      providerOrModelWorkMayStart: false,
+      tradingExecutionAuthority: false,
+    });
+
+    const missingWait = await fetch(
+      `${baseUrl}/api/v1/agent-operator/runs/${missingId}/wait?waitMs=100`,
+    );
+    expect(missingWait.status).toBe(404);
+    await expect(missingWait.json()).resolves.toMatchObject({
+      ok: false,
+      diagnostic: "Agent run is unavailable",
+      providerRequestsStartedByRead: 0,
+      valueMovingAuthority: false,
+    });
   });
 
   it("allows incremented loopback Studio origins without reflecting remote origins", async () => {

--- a/plans/external-agent-operator-surface.md
+++ b/plans/external-agent-operator-surface.md
@@ -83,11 +83,19 @@ qualification, or verification verdict logic.
   leakage, unbounded collections, and inconsistent count/truncation metadata.
 - Studio uses the same preview binding and a preview-derived idempotency key;
   the old global fixed browser authorization reference has been removed.
+- `agent run wait` waits on the dispatcher's existing in-process completion
+  promise with a bounded timeout. It never polls durable storage, creates a run,
+  cancels work, or consumes dispatch authority; detached prepared runs are
+  reported as `NOT_AWAITABLE_IN_THIS_PROCESS`.
+- Runtime resume is explicitly not advertised. `INTERRUPTED` is terminal in the
+  current substrate and startup recovery deliberately infers no retry authority.
+  A new attempt must pass through a new preview and authorization binding.
 
 ## Next implementation frontier
 
-The machine surface can now discover, inspect, preview, execute, and poll an
-exact research run without gaining trading authority. The next mainline slice
-should add a bounded wait/resume contract for interrupted work, retain machine
-operator-friction measurements, and test the complete zero-context journey
-with a fresh external Agent session under an explicit context budget.
+The machine surface can now discover, inspect, preview, execute, and boundedly
+wait for an exact research run without gaining trading authority. The next
+mainline slice should retain machine operator-friction measurements and test
+the complete zero-context journey with a fresh external Agent session under an
+explicit context budget. True runtime resume remains a separate substrate and
+adapter-state-machine change, not a CLI fiction.


### PR DESCRIPTION
## Outcome

Adds a bounded server-side wait for already-authorized research runs, so external Agents do not need a client polling loop.

## Contract

- waits only on the dispatcher process existing completion promise
- defaults to 30 seconds; accepts 1..60000ms and never exceeds the run profile wall-clock budget
- returns `COMPLETED`, `TIMEOUT`, `ALREADY_TERMINAL`, or `NOT_AWAITABLE_IN_THIS_PROCESS`
- never creates, cancels, retries, or redispatches a run
- exposes the same bounded run-bound records and literal-zero read effects as exact inspection
- deliberately does not add fake resume: `INTERRUPTED` remains terminal and a new attempt requires a new preview and authorization ref

## Verification

- `pnpm check`
- `pnpm test`
- control-plane: 803 tests
- CLI: 33 tests
- Studio: 30 tests

Grok Build topic session `61394efb-bf73-45af-aac2-a995c46d2585` audited the substrate and supplied the dispatcher Promise-wait primitive. Codex completed and reviewed the HTTP/CLI authority contract, budget enforcement, documentation, and full qualification.