### PR TITLE
feat: add OpenAlice Harness Studio capability

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -6,6 +6,16 @@ current dependency graph) is qualified on Node 22.22.1; Node 24 remains
 compatible but is no longer required. `@types/node` follows the Node 22 line so
 type checking cannot silently admit a Node 24-only API.
 
+OpenAlice Harness Studio is a mainline interoperability surface, not a second
+product runtime. Standalone and managed launches resolve through one shared
+configuration shape. Standalone mode default-fills `127.0.0.1:5173` for the
+Studio entry and `127.0.0.1:4100` for the control plane while retaining Vite's
+entry-port increment behavior. `OPENALICE_CAPABILITY=studio` replaces those
+defaults with two validated host allocations, makes the entry port strict, and
+keeps the same supervisor-owned child lifecycle and dynamic proxy topology.
+The manifest and full-process qualification must remain provider-free and must
+cover `/health`, readiness, HTML, and SSE through the allocated entry port.
+
 The 2026-08-20 first-time-user audit used one retained Grok Build session
 (`01a01dc2-1618-7853-984b-ba85974960eb`) against a clean `origin/main`
 worktree. The documented install, workspace check, and test path passed, while

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -8,7 +8,7 @@
     "check": "tsc -b",
     "dev": "vite",
     "preview": "vite preview",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run --passWithNoTests src studio-runtime.test.ts",
     "test:coverage": "vitest run --passWithNoTests"
   },
   "dependencies": {

--- a/apps/studio/studio-runtime.test.ts
+++ b/apps/studio/studio-runtime.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { studioViteConfig } from "./vite.config";
+
+describe("studioViteConfig", () => {
+  it("uses exact OpenAlice host, ports, proxy, and strict binding", () => {
+    const config = studioViteConfig({
+      OPENALICE_CAPABILITY: "studio",
+      OPENALICE_CAPABILITY_HOST: "127.0.0.1",
+      OPENALICE_CAPABILITY_PORTS: JSON.stringify({
+        http: 49321,
+        controlPlane: 49322,
+      }),
+      OPENALICE_CAPABILITY_NO_OPEN: "1",
+    });
+
+    expect(config.server).toMatchObject({
+      host: "127.0.0.1",
+      port: 49321,
+      strictPort: true,
+      open: false,
+      proxy: {
+        "/api": "http://127.0.0.1:49322",
+        "/health": "http://127.0.0.1:49322",
+      },
+    });
+  });
+
+  it("treats independent mode as the same config with default-filled ports", () => {
+    const config = studioViteConfig({});
+
+    expect(config.server).toMatchObject({
+      host: "127.0.0.1",
+      port: 5173,
+      strictPort: false,
+      open: false,
+      proxy: {
+        "/api": "http://127.0.0.1:4100",
+        "/health": "http://127.0.0.1:4100",
+      },
+    });
+  });
+});

--- a/apps/studio/vite.config.ts
+++ b/apps/studio/vite.config.ts
@@ -1,26 +1,34 @@
 import path from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, type UserConfig } from "vite";
+import { resolveStudioRuntimeConfig } from "../../scripts/studio-runtime-config.mjs";
 
-export default defineConfig({
-  plugins: [react(), tailwindcss()],
-  server: {
-    // Bind the same loopback family used by other local workspaces so Vite can
-    // actually observe a port collision and increment to 5174, 5175, ... .
-    // Binding the default `localhost` can otherwise admit ::1:5173 while a
-    // different app already owns 127.0.0.1:5173.
-    host: "127.0.0.1",
-    port: 5173,
-    strictPort: false,
-    proxy: {
-      "/api": "http://127.0.0.1:4100",
-      "/health": "http://127.0.0.1:4100",
+export function studioViteConfig(
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+): UserConfig {
+  const runtime = resolveStudioRuntimeConfig(environment);
+  const controlPlaneUrl = `http://${runtime.host}:${runtime.controlPlanePort}`;
+  return {
+    plugins: [react(), tailwindcss()],
+    server: {
+      // Independent mode keeps Vite's 5173, 5174, ... development behavior.
+      // OpenAlice mode binds the exact allocated loopback port and fails closed.
+      host: runtime.host,
+      port: runtime.httpPort,
+      strictPort: runtime.strictHttpPort,
+      open: runtime.openBrowser,
+      proxy: {
+        "/api": controlPlaneUrl,
+        "/health": controlPlaneUrl,
+      },
     },
-  },
-  resolve: {
-    alias: {
-      "@": path.resolve(import.meta.dirname, "./src"),
+    resolve: {
+      alias: {
+        "@": path.resolve(import.meta.dirname, "./src"),
+      },
     },
-  },
-});
+  };
+}
+
+export default defineConfig(() => studioViteConfig());

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -26,6 +26,31 @@ increments the port when it is already occupied. Use the URL Vite prints. The
 command supervises both children: if either exits, the other is stopped too, so
 a control-plane bind failure cannot look like a successfully started Studio.
 
+### OpenAlice Harness Studio
+
+The root [`harness.json`](../harness.json) advertises the standard `studio`
+capability. OpenAlice supplies one entry port and one internal control-plane
+port. Both launch modes use the same resolved runtime configuration: standalone
+mode fills the defaults above, while managed mode replaces them with the exact
+host ports and enables strict entry-port binding.
+
+A reproducible managed launch looks like this (choose two currently unused,
+different loopback ports):
+
+```bash
+OPENALICE_CAPABILITY=studio \
+OPENALICE_CAPABILITY_HOST=127.0.0.1 \
+OPENALICE_CAPABILITY_PORTS='{"http":49321,"controlPlane":49322}' \
+OPENALICE_CAPABILITY_NO_OPEN=1 \
+pnpm studio
+```
+
+In managed mode, malformed or incomplete port input fails before either child
+starts. An occupied allocated port also fails the command; Vite never advances
+to another port. The Studio entry proxies `/health`, `/api`, and SSE traffic to
+the injected internal control-plane port. Standalone `pnpm studio` retains its
+existing `5173`, `5174`, … behavior.
+
 Useful health checks:
 
 ```bash
@@ -157,7 +182,8 @@ Then verify in Studio:
 ## Troubleshooting
 
 - **Studio moved to 5174/5175:** expected Vite port increment; use the URL
-  printed by the process.
+  printed by the process. This applies only to standalone mode; OpenAlice
+  managed mode fails on an occupied allocated port.
 - **Studio says offline:** check `http://127.0.0.1:4100/health` and the control
   plane terminal output.
 - **Model unavailable:** inspect the runtime/credential posture in Readiness.

--- a/harness.json
+++ b/harness.json
@@ -1,0 +1,12 @@
+{
+  "manifestVersion": 1,
+  "version": "0.0.0-dev",
+  "capabilities": {
+    "studio": {
+      "command": ["pnpm", "studio"],
+      "ports": ["http", "controlPlane"],
+      "entryPort": "http",
+      "readinessPath": "/health"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "pmh": "pnpm --silent --filter @pmh/cli build && node packages/cli/dist/main.js",
     "studio": "node scripts/studio.mjs",
     "studio:build": "pnpm --filter @pmh/control-plane build && pnpm --filter @pmh/studio build",
-    "test": "node --test scripts/studio-supervisor.test.mjs && pnpm -r test",
+    "test": "node --test scripts/studio-runtime-config.test.mjs scripts/studio-supervisor.test.mjs scripts/studio-harness-smoke.test.mjs && pnpm -r test",
     "test:coverage": "pnpm -r test:coverage"
   },
   "devDependencies": {

--- a/packages/control-plane/src/main.ts
+++ b/packages/control-plane/src/main.ts
@@ -1,5 +1,7 @@
 import { loadLocalEnvironment } from "./local-environment.js";
 import { startControlPlane } from "./server.js";
+import { resolveStudioRuntimeConfig } from "../../../scripts/studio-runtime-config.mjs";
 
 loadLocalEnvironment();
-await startControlPlane();
+const runtime = resolveStudioRuntimeConfig();
+await startControlPlane(runtime.controlPlanePort, runtime.host);

--- a/scripts/studio-harness-smoke.test.mjs
+++ b/scripts/studio-harness-smoke.test.mjs
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+async function allocateLoopbackPorts(count) {
+  const servers = [];
+  try {
+    for (let index = 0; index < count; index += 1) {
+      const server = createServer();
+      await new Promise((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      servers.push(server);
+    }
+    return servers.map((server) => {
+      const address = server.address();
+      assert.ok(address !== null && typeof address === "object");
+      return address.port;
+    });
+  } finally {
+    await Promise.all(servers.map((server) =>
+      new Promise((resolve) => server.close(resolve))
+    ));
+  }
+}
+
+async function fetchUntilReady(url, deadline) {
+  let diagnostic = "no response";
+  while (Date.now() < deadline) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 2_000);
+    try {
+      const response = await fetch(url, { signal: controller.signal });
+      if (response.ok) return response;
+      diagnostic = `HTTP ${response.status}: ${await response.text()}`;
+    } catch (error) {
+      diagnostic = error instanceof Error ? error.message : String(error);
+    } finally {
+      clearTimeout(timer);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`timed out waiting for ${url}: ${diagnostic}`);
+}
+
+test("starts the complete Studio on exact OpenAlice loopback ports", {
+  timeout: 90_000,
+}, async () => {
+  const pnpmExecutable = process.env.npm_execpath ?? "pnpm";
+  const packageManagerIsScript = /\.(?:c?js|mjs)$/u.test(pnpmExecutable);
+  const [httpPort, controlPlanePort] = await allocateLoopbackPorts(2);
+  const directory = await mkdtemp(join(tmpdir(), "auto-prediction-harness-"));
+  const output = [];
+  const child = spawn(
+    packageManagerIsScript ? process.execPath : pnpmExecutable,
+    packageManagerIsScript ? [pnpmExecutable, "studio"] : ["studio"],
+    {
+    cwd: new URL("..", import.meta.url),
+    env: {
+      ...process.env,
+      OPENALICE_CAPABILITY: "studio",
+      OPENALICE_CAPABILITY_HOST: "127.0.0.1",
+      OPENALICE_CAPABILITY_PORTS: JSON.stringify({ http: httpPort, controlPlane: controlPlanePort }),
+      OPENALICE_CAPABILITY_NO_OPEN: "1",
+      PMH_STATE_DB: join(directory, "control-plane.sqlite"),
+    },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  child.stdout.on("data", (chunk) => output.push(chunk.toString()));
+  child.stderr.on("data", (chunk) => output.push(chunk.toString()));
+  const exit = new Promise((resolve) => child.once("exit", (code, signal) =>
+    resolve({ code, signal })
+  ));
+
+  try {
+    const entry = `http://127.0.0.1:${httpPort}`;
+    const deadline = Date.now() + 60_000;
+    const health = await fetchUntilReady(`${entry}/health`, deadline);
+    assert.equal((await health.json()).ok, true);
+
+    const readiness = await fetchUntilReady(`${entry}/api/v1/readiness`, deadline);
+    assert.equal((await readiness.json()).schemaVersion, "pmh.startup-readiness.v1");
+
+    const html = await fetchUntilReady(entry, deadline);
+    assert.match(await html.text(), /<!doctype html>/iu);
+
+    const controller = new AbortController();
+    const events = await fetch(`${entry}/api/v1/events`, {
+      headers: { accept: "text/event-stream" },
+      signal: controller.signal,
+    });
+    assert.equal(events.status, 200);
+    assert.match(events.headers.get("content-type") ?? "", /^text\/event-stream/u);
+    controller.abort();
+
+    assert.match(output.join(""), new RegExp(`127\\.0\\.0\\.1:${httpPort}`));
+    assert.doesNotMatch(output.join(""), /Local:\s+http:\/\/127\.0\.0\.1:517[3-9]/u);
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) child.kill("SIGTERM");
+    let shutdownTimer;
+    try {
+      await Promise.race([
+        exit,
+        new Promise((_, reject) => {
+          shutdownTimer = setTimeout(
+            () => reject(new Error(`Studio did not stop cleanly:\n${output.join("")}`)),
+            10_000,
+          );
+        }),
+      ]);
+    } finally {
+      clearTimeout(shutdownTimer);
+    }
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/scripts/studio-runtime-config.d.mts
+++ b/scripts/studio-runtime-config.d.mts
@@ -1,0 +1,12 @@
+export type StudioRuntimeConfig = Readonly<{
+  managed: boolean;
+  host: string;
+  httpPort: number;
+  controlPlanePort: number;
+  strictHttpPort: boolean;
+  openBrowser: false;
+}>;
+
+export function resolveStudioRuntimeConfig(
+  environment?: Readonly<Record<string, string | undefined>>,
+): StudioRuntimeConfig;

--- a/scripts/studio-runtime-config.mjs
+++ b/scripts/studio-runtime-config.mjs
@@ -1,0 +1,62 @@
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
+
+function managedPort(value, name) {
+  if (!Number.isInteger(value) || value < 1 || value > 65_535) {
+    throw new Error(
+      `OPENALICE_CAPABILITY_PORTS.${name} must be an integer from 1 to 65535`,
+    );
+  }
+  return value;
+}
+
+export function resolveStudioRuntimeConfig(environment = process.env) {
+  const managed = environment.OPENALICE_CAPABILITY === "studio";
+  if (!managed) return Object.freeze({
+    managed,
+    host: "127.0.0.1",
+    httpPort: 5_173,
+    controlPlanePort: 4_100,
+    strictHttpPort: managed,
+    openBrowser: false,
+  });
+
+  const host = environment.OPENALICE_CAPABILITY_HOST;
+  if (typeof host !== "string" || !LOOPBACK_HOSTS.has(host)) {
+    throw new Error(
+      "OPENALICE_CAPABILITY_HOST must be 127.0.0.1, ::1, or localhost in studio mode",
+    );
+  }
+  const encodedPorts = environment.OPENALICE_CAPABILITY_PORTS;
+  if (typeof encodedPorts !== "string" || encodedPorts.trim() === "") {
+    throw new Error("OPENALICE_CAPABILITY_PORTS is required in studio mode");
+  }
+  let decoded;
+  try {
+    decoded = JSON.parse(encodedPorts);
+  } catch {
+    throw new Error("OPENALICE_CAPABILITY_PORTS must be valid JSON");
+  }
+  if (decoded === null || typeof decoded !== "object" || Array.isArray(decoded)) {
+    throw new Error("OPENALICE_CAPABILITY_PORTS must be a JSON object");
+  }
+  const keys = Object.keys(decoded).sort();
+  if (keys.length !== 2 || keys[0] !== "controlPlane" || keys[1] !== "http") {
+    throw new Error(
+      "OPENALICE_CAPABILITY_PORTS must contain exactly http and controlPlane",
+    );
+  }
+  const httpPort = managedPort(decoded.http, "http");
+  const controlPlanePort = managedPort(decoded.controlPlane, "controlPlane");
+  if (httpPort === controlPlanePort) {
+    throw new Error("OpenAlice studio http and controlPlane ports must be different");
+  }
+
+  return Object.freeze({
+    managed,
+    host,
+    httpPort,
+    controlPlanePort,
+    strictHttpPort: managed,
+    openBrowser: false,
+  });
+}

--- a/scripts/studio-runtime-config.test.mjs
+++ b/scripts/studio-runtime-config.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import { resolveStudioRuntimeConfig } from "./studio-runtime-config.mjs";
+
+test("publishes the OpenAlice Harness Studio capability manifest", async () => {
+  const manifest = JSON.parse(await readFile(
+    new URL("../harness.json", import.meta.url),
+    "utf8",
+  ));
+  assert.deepEqual(manifest, {
+    manifestVersion: 1,
+    version: "0.0.0-dev",
+    capabilities: {
+      studio: {
+        command: ["pnpm", "studio"],
+        ports: ["http", "controlPlane"],
+        entryPort: "http",
+        readinessPath: "/health",
+      },
+    },
+  });
+});
+
+test("parses exact managed Studio ports", () => {
+  assert.deepEqual(resolveStudioRuntimeConfig({
+    OPENALICE_CAPABILITY: "studio",
+    OPENALICE_CAPABILITY_HOST: "127.0.0.1",
+    OPENALICE_CAPABILITY_PORTS: '{"http":49321,"controlPlane":49322}',
+    OPENALICE_CAPABILITY_NO_OPEN: "1",
+  }), {
+    managed: true,
+    host: "127.0.0.1",
+    httpPort: 49_321,
+    controlPlanePort: 49_322,
+    strictHttpPort: true,
+    openBrowser: false,
+  });
+});
+
+test("preserves independent Studio defaults", () => {
+  assert.deepEqual(resolveStudioRuntimeConfig({}), {
+    managed: false,
+    host: "127.0.0.1",
+    httpPort: 5_173,
+    controlPlanePort: 4_100,
+    strictHttpPort: false,
+    openBrowser: false,
+  });
+  assert.equal(resolveStudioRuntimeConfig({
+    OPENALICE_CAPABILITY: "another-capability",
+  }).managed, false);
+});
+
+for (const [name, environment, diagnostic] of [
+  ["missing ports", {
+    OPENALICE_CAPABILITY: "studio",
+    OPENALICE_CAPABILITY_HOST: "127.0.0.1",
+  }, /PORTS is required/],
+  ["invalid JSON", {
+    OPENALICE_CAPABILITY: "studio",
+    OPENALICE_CAPABILITY_HOST: "127.0.0.1",
+    OPENALICE_CAPABILITY_PORTS: "not-json",
+  }, /valid JSON/],
+  ["missing named port", {
+    OPENALICE_CAPABILITY: "studio",
+    OPENALICE_CAPABILITY_HOST: "127.0.0.1",
+    OPENALICE_CAPABILITY_PORTS: '{"http":49321}',
+  }, /exactly http and controlPlane/],
+  ["non-integer port", {
+    OPENALICE_CAPABILITY: "studio",
+    OPENALICE_CAPABILITY_HOST: "127.0.0.1",
+    OPENALICE_CAPABILITY_PORTS: '{"http":49321.5,"controlPlane":49322}',
+  }, /http must be an integer/],
+  ["out-of-range port", {
+    OPENALICE_CAPABILITY: "studio",
+    OPENALICE_CAPABILITY_HOST: "127.0.0.1",
+    OPENALICE_CAPABILITY_PORTS: '{"http":0,"controlPlane":49322}',
+  }, /http must be an integer/],
+  ["duplicate ports", {
+    OPENALICE_CAPABILITY: "studio",
+    OPENALICE_CAPABILITY_HOST: "127.0.0.1",
+    OPENALICE_CAPABILITY_PORTS: '{"http":49321,"controlPlane":49321}',
+  }, /must be different/],
+  ["remote host", {
+    OPENALICE_CAPABILITY: "studio",
+    OPENALICE_CAPABILITY_HOST: "0.0.0.0",
+    OPENALICE_CAPABILITY_PORTS: '{"http":49321,"controlPlane":49322}',
+  }, /must be 127\.0\.0\.1/],
+]) {
+  test(`fails closed for ${name}`, () => {
+    assert.throws(() => resolveStudioRuntimeConfig(environment), diagnostic);
+  });
+}

--- a/scripts/studio-supervisor.mjs
+++ b/scripts/studio-supervisor.mjs
@@ -2,12 +2,14 @@ import { spawn } from "node:child_process";
 import { createServer } from "node:net";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
+import { resolveStudioRuntimeConfig } from "./studio-runtime-config.mjs";
 
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
 export function assertPortAvailable({
   host = "127.0.0.1",
   port = 4_100,
+  name = "control-plane",
   createProbeServer = createServer,
 } = {}) {
   return new Promise((resolveAvailable, rejectUnavailable) => {
@@ -16,7 +18,7 @@ export function assertPortAvailable({
     probe.once("error", (error) => {
       if (error.code === "EADDRINUSE") {
         rejectUnavailable(new Error(
-          `control-plane port http://${host}:${port} is already in use`,
+          `${name} port http://${host}:${port} is already in use`,
         ));
         return;
       }
@@ -29,6 +31,24 @@ export function assertPortAvailable({
       });
     });
   });
+}
+
+export async function assertStudioPortsAvailable(
+  runtime = resolveStudioRuntimeConfig(),
+  checkPort = assertPortAvailable,
+) {
+  await checkPort({
+    host: runtime.host,
+    port: runtime.controlPlanePort,
+    name: "control-plane",
+  });
+  if (runtime.strictHttpPort) {
+    await checkPort({
+      host: runtime.host,
+      port: runtime.httpPort,
+      name: "Studio",
+    });
+  }
 }
 
 export function stopChild(child, signal = "SIGTERM") {
@@ -78,6 +98,7 @@ export function startStudioChildren({
   spawnProcess = spawn,
   nodeExecutable = process.execPath,
   pnpmExecutable = process.env.npm_execpath,
+  environment = process.env,
 } = {}) {
   if (pnpmExecutable === undefined || pnpmExecutable.length === 0) {
     throw new Error("pnpm studio must be launched through pnpm");
@@ -90,7 +111,7 @@ export function startStudioChildren({
       [pnpmExecutable, "--filter", packageName, ...command],
       {
         cwd: repositoryRoot,
-        env: process.env,
+        env: environment,
         stdio: "inherit",
         detached: process.platform !== "win32",
       },

--- a/scripts/studio-supervisor.test.mjs
+++ b/scripts/studio-supervisor.test.mjs
@@ -5,6 +5,7 @@ import test from "node:test";
 
 import {
   assertPortAvailable,
+  assertStudioPortsAvailable,
   startStudioChildren,
   superviseStudio,
 } from "./studio-supervisor.mjs";
@@ -76,6 +77,57 @@ test("rejects before either child starts when port 4100 is occupied", async () =
   await new Promise((resolveClose) => occupant.close(resolveClose));
 });
 
+test("preflights both exact ports only in OpenAlice managed mode", async () => {
+  const calls = [];
+  const checkPort = async (input) => calls.push(input);
+  await assertStudioPortsAvailable({
+    managed: true,
+    host: "127.0.0.1",
+    httpPort: 49_321,
+    controlPlanePort: 49_322,
+    strictHttpPort: true,
+  }, checkPort);
+  assert.deepEqual(calls, [
+    { host: "127.0.0.1", port: 49_322, name: "control-plane" },
+    { host: "127.0.0.1", port: 49_321, name: "Studio" },
+  ]);
+
+  calls.length = 0;
+  await assertStudioPortsAvailable({
+    managed: false,
+    host: "127.0.0.1",
+    httpPort: 5_173,
+    controlPlanePort: 4_100,
+    strictHttpPort: false,
+  }, checkPort);
+  assert.deepEqual(calls, [
+    { host: "127.0.0.1", port: 4_100, name: "control-plane" },
+  ]);
+});
+
+test("rejects an occupied managed Studio entry port instead of incrementing", async () => {
+  const occupant = createServer();
+  await new Promise((resolveListen) => occupant.listen(0, "127.0.0.1", resolveListen));
+  const address = occupant.address();
+  assert.ok(address !== null && typeof address === "object");
+  const controlPlaneProbe = createServer();
+  await new Promise((resolveListen) =>
+    controlPlaneProbe.listen(0, "127.0.0.1", resolveListen)
+  );
+  const controlPlaneAddress = controlPlaneProbe.address();
+  assert.ok(controlPlaneAddress !== null && typeof controlPlaneAddress === "object");
+  const controlPlanePort = controlPlaneAddress.port;
+  await new Promise((resolveClose) => controlPlaneProbe.close(resolveClose));
+  await assert.rejects(assertStudioPortsAvailable({
+    managed: true,
+    host: "127.0.0.1",
+    httpPort: address.port,
+    controlPlanePort,
+    strictHttpPort: true,
+  }), /Studio port .* is already in use/);
+  await new Promise((resolveClose) => occupant.close(resolveClose));
+});
+
 test("runs the control plane without a watcher that can hide startup failure", () => {
   const calls = [];
   startStudioChildren({
@@ -85,10 +137,13 @@ test("runs the control plane without a watcher that can hide startup failure", (
       calls.push(args);
       return fakeChild();
     },
+    environment: { OPENALICE_CAPABILITY: "studio" },
   });
 
   assert.deepEqual(calls.map(([executable, args]) => [executable, args]), [
     ["/node", ["/pnpm.cjs", "--filter", "@pmh/control-plane", "exec", "tsx", "src/main.ts"]],
     ["/node", ["/pnpm.cjs", "--filter", "@pmh/studio", "dev"]],
   ]);
+  assert.equal(calls[0][2].env.OPENALICE_CAPABILITY, "studio");
+  assert.equal(calls[1][2].env.OPENALICE_CAPABILITY, "studio");
 });

--- a/scripts/studio.mjs
+++ b/scripts/studio.mjs
@@ -1,13 +1,15 @@
 import {
-  assertPortAvailable,
+  assertStudioPortsAvailable,
   startStudioChildren,
   stopChild,
   superviseStudio,
 } from "./studio-supervisor.mjs";
+import { resolveStudioRuntimeConfig } from "./studio-runtime-config.mjs";
 
 async function main() {
-  await assertPortAvailable();
-  const children = startStudioChildren();
+  const runtime = resolveStudioRuntimeConfig();
+  await assertStudioPortsAvailable(runtime);
+  const children = startStudioChildren({ environment: process.env });
   let shuttingDown = false;
 
   for (const signal of ["SIGINT", "SIGTERM"]) {


### PR DESCRIPTION
## Summary

- publish the standard OpenAlice `studio` capability in `harness.json`
- resolve standalone defaults and managed host/ports through one shared runtime config
- bind Vite and the control plane to injected ports, with strict managed entry-port behavior and dynamic proxies
- retain the existing standalone 4100 plus Vite port-increment experience
- qualify manifest parsing, fail-closed port handling, supervisor lifecycle, HTML, health, readiness, and SSE

## Verification

- `pnpm check`
- `pnpm test`
- `pnpm studio:build`
- `git diff --check`

## Reproduce managed launch

`env OPENALICE_CAPABILITY=studio OPENALICE_CAPABILITY_HOST=127.0.0.1 OPENALICE_CAPABILITY_PORTS='{"http":49321,"controlPlane":49322}' OPENALICE_CAPABILITY_NO_OPEN=1 pnpm studio`