### PR TITLE
chore: set product version to 0.1.0

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -1,5 +1,10 @@
 # Plans
 
+The canonical Auto Prediction product version is **0.1.0**. The root package
+and OpenAlice Harness manifest carry this product version. Private internal
+workspace packages retain independent `0.0.0` identifiers until they acquire a
+real package-release lifecycle; they are not the product version.
+
 The supported runtime baseline is **Node.js 22.19+**. The repository's own
 runtime surface (`node:sqlite`, `import.meta.dirname`, pnpm 11, Vite and the
 current dependency graph) is qualified on Node 22.22.1; Node 24 remains

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 An AI-native research system for finding, testing, and retaining semantic
 arbitrage hypotheses across prediction markets.
 
+Current product version: **0.1.0**.
+
 ![Auto Prediction — AI-native semantic arbitrage research](apps/studio/public/og.png)
 
 The project treats a prediction-market quote as a **traded valuation of a

--- a/harness.json
+++ b/harness.json
@@ -1,6 +1,6 @@
 {
   "manifestVersion": 1,
-  "version": "0.0.0-dev",
+  "version": "0.1.0",
   "capabilities": {
     "studio": {
       "command": ["pnpm", "studio"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prediction-market-harness",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "description": "Auto Prediction: an AI-native semantic arbitrage research harness for prediction markets.",
   "packageManager": "pnpm@11.13.1",

--- a/scripts/studio-runtime-config.test.mjs
+++ b/scripts/studio-runtime-config.test.mjs
@@ -11,7 +11,7 @@ test("publishes the OpenAlice Harness Studio capability manifest", async () => {
   ));
   assert.deepEqual(manifest, {
     manifestVersion: 1,
-    version: "0.0.0-dev",
+    version: "0.1.0",
     capabilities: {
       studio: {
         command: ["pnpm", "studio"],


### PR DESCRIPTION
## Summary

- establish `0.1.0` as the canonical Auto Prediction product version
- expose the same version through the OpenAlice Harness manifest
- document why private internal workspace package versions remain independent
- update manifest qualification

## Verification

- `node --test scripts/studio-runtime-config.test.mjs`
- `pnpm check`
- `git diff --check`