### PR TITLE
chore: unify repository version at 0.1.0

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -1,9 +1,10 @@
 # Plans
 
-The canonical Auto Prediction product version is **0.1.0**. The root package
-and OpenAlice Harness manifest carry this product version. Private internal
-workspace packages retain independent `0.0.0` identifiers until they acquire a
-real package-release lifecycle; they are not the product version.
+The canonical Auto Prediction product version is **0.1.0**. The root package,
+OpenAlice Harness manifest, private workspace packages, Studio, CLI, and
+Agent-runtime client identity carry the same version. Venue adapter identities
+and public fixture-capture User-Agents follow it as well, so every observable
+surface describes one coherent repository release.
 
 The supported runtime baseline is **Node.js 22.19+**. The repository's own
 runtime surface (`node:sqlite`, `import.meta.dirname`, pnpm 11, Vite and the

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/studio",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/capital/package.json
+++ b/packages/capital/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/capital",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.ts" },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/cli",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/control-plane",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/control-plane/src/codex-app-server-transport.ts
+++ b/packages/control-plane/src/codex-app-server-transport.ts
@@ -327,7 +327,7 @@ export function createCodexAppServerConnectionFactory(input: Readonly<{
       clientInfo: {
         name: "prediction-market-harness",
         title: "Prediction Market Harness",
-        version: "0.0.0",
+        version: "0.1.0",
       },
       capabilities: {
         experimentalApi: true,

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/domain",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/evidence/package.json
+++ b/packages/evidence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/evidence",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/execution/package.json
+++ b/packages/execution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/execution",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.ts" },

--- a/packages/liquidity/package.json
+++ b/packages/liquidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/liquidity",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.ts" },

--- a/packages/market-state/package.json
+++ b/packages/market-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/market-state",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/opportunity/package.json
+++ b/packages/opportunity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/opportunity",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.ts" },

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/protocol",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/protocol/test/capabilities.test.ts
+++ b/packages/protocol/test/capabilities.test.ts
@@ -7,7 +7,7 @@ describe("venue capability manifest", () => {
       assertManifest({
         venueId: "gemini-predictions",
         displayName: "Gemini Prediction Markets",
-        adapterVersion: "0.0.0",
+        adapterVersion: "0.1.0",
         protocolIdentity: "rest-v1:2026-07-30",
         officialSources: [
           "https://developer.gemini.com/prediction-markets/prediction-markets",

--- a/packages/risk/package.json
+++ b/packages/risk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/risk",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.ts" },

--- a/packages/venue-gemini/package.json
+++ b/packages/venue-gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/venue-gemini",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.ts" },

--- a/packages/venue-gemini/src/index.ts
+++ b/packages/venue-gemini/src/index.ts
@@ -245,7 +245,7 @@ export class GeminiSandboxInertOrderGateway
 export const geminiManifest: VenueManifest = {
   venueId: "gemini-predictions",
   displayName: "Gemini Prediction Markets",
-  adapterVersion: "0.0.0",
+  adapterVersion: "0.1.0",
   protocolIdentity: "prediction-markets-v1:2026-07-30",
   officialSources: [
     "https://developer.gemini.com/prediction-markets/prediction-markets",

--- a/packages/venue-kalshi/package.json
+++ b/packages/venue-kalshi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/venue-kalshi",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.ts" },

--- a/packages/venue-kalshi/src/index.ts
+++ b/packages/venue-kalshi/src/index.ts
@@ -139,7 +139,7 @@ export class KalshiDemoInertOrderGateway
 export const kalshiManifest: VenueManifest = {
   venueId: "kalshi",
   displayName: "Kalshi",
-  adapterVersion: "0.0.0",
+  adapterVersion: "0.1.0",
   protocolIdentity: "trade-api-v2:2026-07-31",
   officialSources: ["https://docs.kalshi.com/welcome"],
   mechanisms: ["centralized binary and multivariate event contracts"],

--- a/packages/venue-limitless/package.json
+++ b/packages/venue-limitless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/venue-limitless",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.ts" },

--- a/packages/venue-limitless/src/index.ts
+++ b/packages/venue-limitless/src/index.ts
@@ -68,7 +68,7 @@ function inferTick(prices: readonly bigint[]): bigint {
 export const limitlessManifest: VenueManifest = {
   venueId: "limitless",
   displayName: "Limitless",
-  adapterVersion: "0.0.0",
+  adapterVersion: "0.1.0",
   protocolIdentity: "markets-socket-io:2026-07-31",
   officialSources: [
     "https://docs.limitless.exchange/developers/websocket-events",

--- a/packages/venue-myriad/package.json
+++ b/packages/venue-myriad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/venue-myriad",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.ts" },

--- a/packages/venue-myriad/src/index.ts
+++ b/packages/venue-myriad/src/index.ts
@@ -40,7 +40,7 @@ const ResponseSchema = z.object({
 export const myriadManifest: VenueManifest = {
   venueId: "myriad",
   displayName: "Myriad Markets",
-  adapterVersion: "0.0.0",
+  adapterVersion: "0.1.0",
   protocolIdentity: "api-v2.0.4:2026-07-31",
   officialSources: [
     "https://docs.myriad.markets/builders/myriad-api-reference",

--- a/packages/venue-opinion/package.json
+++ b/packages/venue-opinion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/venue-opinion",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.ts" },

--- a/packages/venue-opinion/src/index.ts
+++ b/packages/venue-opinion/src/index.ts
@@ -54,7 +54,7 @@ export type OpinionOrderbookBestAsk = Readonly<{
 export const opinionManifest: VenueManifest = {
   venueId: "opinion",
   displayName: "Opinion",
-  adapterVersion: "0.0.0",
+  adapterVersion: "0.1.0",
   protocolIdentity: "openapi:2026-07-31",
   officialSources: [
     "https://docs.opinion.trade/developer-guide/opinion-open-api/overview",

--- a/packages/venue-polymarket-us/package.json
+++ b/packages/venue-polymarket-us/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/venue-polymarket-us",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.ts" },

--- a/packages/venue-polymarket-us/src/index.ts
+++ b/packages/venue-polymarket-us/src/index.ts
@@ -149,7 +149,7 @@ export type PolymarketUsBboObservation = Readonly<{
 export const polymarketUsManifest: VenueManifest = {
   venueId: "polymarket-us",
   displayName: "Polymarket US",
-  adapterVersion: "0.0.0",
+  adapterVersion: "0.1.0",
   protocolIdentity: "gateway-rest-v1:2026-08-01",
   officialSources: [
     "https://docs.polymarket.us/api-reference/introduction",

--- a/packages/venue-polymarket/package.json
+++ b/packages/venue-polymarket/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/venue-polymarket",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.ts" },

--- a/packages/venue-polymarket/src/index.ts
+++ b/packages/venue-polymarket/src/index.ts
@@ -64,7 +64,7 @@ const BookMessageSchema = z.object({
 export const polymarketManifest: VenueManifest = {
   venueId: "polymarket-global",
   displayName: "Polymarket Predictions",
-  adapterVersion: "0.0.0",
+  adapterVersion: "0.1.0",
   protocolIdentity: "gamma-rest+combo-rfq:2026-07-31",
   officialSources: ["https://docs.polymarket.com/"],
   mechanisms: ["Polygon conditional outcome-token CLOB", "Combo/RFQ"],

--- a/scripts/capture-public-fixtures.mjs
+++ b/scripts/capture-public-fixtures.mjs
@@ -142,7 +142,7 @@ async function capture(name) {
   const response = await fetch(definition.sourceUrl, {
     headers: {
       accept: "application/json",
-      "user-agent": "prediction-market-harness-fixture-capture/0.0.0",
+      "user-agent": "prediction-market-harness-fixture-capture/0.1.0",
     },
     redirect: "follow",
     signal: AbortSignal.timeout(30_000),

--- a/scripts/capture-public-stream-fixtures.mjs
+++ b/scripts/capture-public-stream-fixtures.mjs
@@ -34,7 +34,7 @@ function makeFrame(rawText, eventName, ordinal) {
 
 async function fetchJson(url) {
   const response = await fetch(url, {
-    headers: { "user-agent": "prediction-market-harness/0.0.0" },
+    headers: { "user-agent": "prediction-market-harness/0.1.0" },
   });
   if (!response.ok) {
     throw new Error(`${url} returned HTTP ${response.status}`);


### PR DESCRIPTION
## Summary

- align every private workspace package and Studio with product version `0.1.0`
- align Agent client identity and all venue adapter identities
- align public fixture-capture User-Agents
- record one coherent repository release version in the plan ledger

## Verification

- no observable `0.0.0` version strings remain
- `pnpm check`
- `pnpm test`
- `git diff --check`