### PR TITLE
feat: publish generic Harness web surface

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -1,7 +1,7 @@
 # Plans
 
-The canonical Auto Prediction product version is **0.1.0**. The root package,
-OpenAlice Harness manifest, private workspace packages, Studio, CLI, and
+The canonical Auto Prediction product version is **0.1.1**. The root package,
+Harness manifest, private workspace packages, Studio, CLI, and
 Agent-runtime client identity carry the same version. Venue adapter identities
 and public fixture-capture User-Agents follow it as well, so every observable
 surface describes one coherent repository release.
@@ -12,15 +12,16 @@ current dependency graph) is qualified on Node 22.22.1; Node 24 remains
 compatible but is no longer required. `@types/node` follows the Node 22 line so
 type checking cannot silently admit a Node 24-only API.
 
-OpenAlice Harness Studio is a mainline interoperability surface, not a second
-product runtime. Standalone and managed launches resolve through one shared
-configuration shape. Standalone mode default-fills `127.0.0.1:5173` for the
-Studio entry and `127.0.0.1:4100` for the control plane while retaining Vite's
-entry-port increment behavior. `OPENALICE_CAPABILITY=studio` replaces those
-defaults with two validated host allocations, makes the entry port strict, and
-keeps the same supervisor-owned child lifecycle and dynamic proxy topology.
-The manifest and full-process qualification must remain provider-free and must
-cover `/health`, readiness, HTML, and SSE through the allocated entry port.
+Harness Studio is a vendor-neutral mainline interoperability surface, not a
+second product runtime. Standalone and managed launches resolve through one
+shared configuration shape. Standalone mode default-fills `127.0.0.1:5173` for
+the Studio entry and `127.0.0.1:4100` for the control plane while retaining
+Vite's entry-port increment behavior. `HARNESS_CAPABILITY=studio` replaces
+those defaults with two validated host allocations, makes the entry port
+strict, and keeps the same supervisor-owned child lifecycle and dynamic proxy
+topology. Full-process qualification is provider-free and covers standalone,
+fail-closed injection, root/assets/API/SSE/HMR WebSocket through a Surface Host,
+browser suppression, and complete SIGTERM port release.
 
 The 2026-08-20 first-time-user audit used one retained Grok Build session
 (`01a01dc2-1618-7853-984b-ba85974960eb`) against a clean `origin/main`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 An AI-native research system for finding, testing, and retaining semantic
 arbitrage hypotheses across prediction markets.
 
-Current product version: **0.1.0**.
+Current product version: **0.1.1**.
 
 ![Auto Prediction — AI-native semantic arbitrage research](apps/studio/public/og.png)
 

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/studio",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/studio/studio-runtime.test.ts
+++ b/apps/studio/studio-runtime.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from "vitest";
 import { studioViteConfig } from "./vite.config";
 
 describe("studioViteConfig", () => {
-  it("uses exact OpenAlice host, ports, proxy, and strict binding", () => {
+  it("uses exact Harness host, ports, proxy, strict binding, and surface hosts", () => {
     const config = studioViteConfig({
-      OPENALICE_CAPABILITY: "studio",
-      OPENALICE_CAPABILITY_HOST: "127.0.0.1",
-      OPENALICE_CAPABILITY_PORTS: JSON.stringify({
+      HARNESS_CAPABILITY: "studio",
+      HARNESS_HOST: "127.0.0.1",
+      HARNESS_PORTS: JSON.stringify({
         http: 49321,
         controlPlane: 49322,
       }),
-      OPENALICE_CAPABILITY_NO_OPEN: "1",
+      HARNESS_NO_OPEN: "1",
     });
 
     expect(config.server).toMatchObject({
@@ -18,6 +18,7 @@ describe("studioViteConfig", () => {
       port: 49321,
       strictPort: true,
       open: false,
+      allowedHosts: [".localhost"],
       proxy: {
         "/api": "http://127.0.0.1:49322",
         "/health": "http://127.0.0.1:49322",
@@ -33,6 +34,7 @@ describe("studioViteConfig", () => {
       port: 5173,
       strictPort: false,
       open: false,
+      allowedHosts: undefined,
       proxy: {
         "/api": "http://127.0.0.1:4100",
         "/health": "http://127.0.0.1:4100",

--- a/apps/studio/vite.config.ts
+++ b/apps/studio/vite.config.ts
@@ -1,8 +1,31 @@
 import path from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { defineConfig, type UserConfig } from "vite";
+import { defineConfig, type Plugin, type UserConfig } from "vite";
 import { resolveStudioRuntimeConfig } from "../../scripts/studio-runtime-config.mjs";
+
+function managedSurfaceClient(managed: boolean): Plugin {
+  return {
+    name: "auto-prediction:managed-surface-client",
+    enforce: "post",
+    transform(code, id) {
+      if (!managed || !id.replaceAll("\\", "/").endsWith("/vite/dist/client/client.mjs")) {
+        return undefined;
+      }
+      const serverHost = /const serverHost = (?:__SERVER_HOST__|"[^"\n]*");/u;
+      const directSocketHost = /const directSocketHost = (?:__HMR_DIRECT_TARGET__|"[^"\n]*");/u;
+      if (!serverHost.test(code) || !directSocketHost.test(code)) {
+        throw new Error("Vite managed client shape changed; refusing to expose bind addresses");
+      }
+      return {
+        code: code
+          .replace(serverHost, "const serverHost = importMetaUrl.host;")
+          .replace(directSocketHost, "const directSocketHost = socketHost;"),
+        map: null,
+      };
+    },
+  };
+}
 
 export function studioViteConfig(
   environment: Readonly<Record<string, string | undefined>> = process.env,
@@ -10,14 +33,15 @@ export function studioViteConfig(
   const runtime = resolveStudioRuntimeConfig(environment);
   const controlPlaneUrl = `http://${runtime.host}:${runtime.controlPlanePort}`;
   return {
-    plugins: [react(), tailwindcss()],
+    plugins: [react(), tailwindcss(), managedSurfaceClient(runtime.managed)],
     server: {
       // Independent mode keeps Vite's 5173, 5174, ... development behavior.
-      // OpenAlice mode binds the exact allocated loopback port and fails closed.
+      // Managed mode binds the exact allocated loopback port and fails closed.
       host: runtime.host,
       port: runtime.httpPort,
       strictPort: runtime.strictHttpPort,
       open: runtime.openBrowser,
+      allowedHosts: runtime.managed ? [".localhost"] : undefined,
       proxy: {
         "/api": controlPlaneUrl,
         "/health": controlPlaneUrl,

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -26,30 +26,42 @@ increments the port when it is already occupied. Use the URL Vite prints. The
 command supervises both children: if either exits, the other is stopped too, so
 a control-plane bind failure cannot look like a successfully started Studio.
 
-### OpenAlice Harness Studio
+### Harness Web Surface
 
 The root [`harness.json`](../harness.json) advertises the standard `studio`
-capability. OpenAlice supplies one entry port and one internal control-plane
-port. Both launch modes use the same resolved runtime configuration: standalone
-mode fills the defaults above, while managed mode replaces them with the exact
-host ports and enables strict entry-port binding.
+capability. OpenAlice or another compatible Harness supervisor supplies one
+entry port and one internal control-plane port. Both launch modes use the same
+resolved runtime configuration: standalone mode fills the defaults above,
+while managed mode replaces them with the exact host ports and enables strict
+entry-port binding.
 
 A reproducible managed launch looks like this (choose two currently unused,
 different loopback ports):
 
 ```bash
-OPENALICE_CAPABILITY=studio \
-OPENALICE_CAPABILITY_HOST=127.0.0.1 \
-OPENALICE_CAPABILITY_PORTS='{"http":49321,"controlPlane":49322}' \
-OPENALICE_CAPABILITY_NO_OPEN=1 \
+HARNESS_CAPABILITY=studio \
+HARNESS_HOST=127.0.0.1 \
+HARNESS_PORTS='{"http":49321,"controlPlane":49322}' \
+HARNESS_NO_OPEN=1 \
 pnpm studio
 ```
 
 In managed mode, malformed or incomplete port input fails before either child
 starts. An occupied allocated port also fails the command; Vite never advances
 to another port. The Studio entry proxies `/health`, `/api`, and SSE traffic to
-the injected internal control-plane port. Standalone `pnpm studio` retains its
-existing `5173`, `5174`, … behavior.
+the injected internal control-plane port. The page, assets, API, SSE, and Vite
+HMR WebSocket remain current-origin paths, including when the Host is an
+`oa-surface-<24 hex>.localhost` Surface Router identity. Standalone `pnpm
+studio` retains its existing `5173`, `5174`, … behavior.
+
+Standalone operators may also select loopback ports explicitly:
+
+```bash
+pnpm studio -- --host 127.0.0.1 --port 15173 --control-plane-port 14100
+```
+
+The same arguments are accepted in managed mode only when they exactly repeat
+the injected values; conflicts fail before either child starts.
 
 Useful health checks:
 
@@ -182,8 +194,8 @@ Then verify in Studio:
 ## Troubleshooting
 
 - **Studio moved to 5174/5175:** expected Vite port increment; use the URL
-  printed by the process. This applies only to standalone mode; OpenAlice
-  managed mode fails on an occupied allocated port.
+  printed by the process. This applies only to standalone mode; Harness managed
+  mode fails on an occupied allocated port.
 - **Studio says offline:** check `http://127.0.0.1:4100/health` and the control
   plane terminal output.
 - **Model unavailable:** inspect the runtime/credential posture in Readiness.

--- a/harness.json
+++ b/harness.json
@@ -1,6 +1,6 @@
 {
   "manifestVersion": 1,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "capabilities": {
     "studio": {
       "command": ["pnpm", "studio"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prediction-market-harness",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Auto Prediction: an AI-native semantic arbitrage research harness for prediction markets.",
   "packageManager": "pnpm@11.13.1",

--- a/packages/capital/package.json
+++ b/packages/capital/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/capital",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.ts" },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/control-plane",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/control-plane/src/codex-app-server-transport.ts
+++ b/packages/control-plane/src/codex-app-server-transport.ts
@@ -327,7 +327,7 @@ export function createCodexAppServerConnectionFactory(input: Readonly<{
       clientInfo: {
         name: "prediction-market-harness",
         title: "Prediction Market Harness",
-        version: "0.1.0",
+        version: "0.1.1",
       },
       capabilities: {
         experimentalApi: true,

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/domain",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/evidence/package.json
+++ b/packages/evidence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/evidence",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/execution/package.json
+++ b/packages/execution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/execution",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.ts" },

--- a/packages/liquidity/package.json
+++ b/packages/liquidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/liquidity",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.ts" },

--- a/packages/market-state/package.json
+++ b/packages/market-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/market-state",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/opportunity/package.json
+++ b/packages/opportunity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/opportunity",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.ts" },

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/protocol",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/protocol/test/capabilities.test.ts
+++ b/packages/protocol/test/capabilities.test.ts
@@ -7,7 +7,7 @@ describe("venue capability manifest", () => {
       assertManifest({
         venueId: "gemini-predictions",
         displayName: "Gemini Prediction Markets",
-        adapterVersion: "0.1.0",
+        adapterVersion: "0.1.1",
         protocolIdentity: "rest-v1:2026-07-30",
         officialSources: [
           "https://developer.gemini.com/prediction-markets/prediction-markets",

--- a/packages/risk/package.json
+++ b/packages/risk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/risk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.ts" },

--- a/packages/venue-gemini/package.json
+++ b/packages/venue-gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/venue-gemini",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.ts" },

--- a/packages/venue-gemini/src/index.ts
+++ b/packages/venue-gemini/src/index.ts
@@ -245,7 +245,7 @@ export class GeminiSandboxInertOrderGateway
 export const geminiManifest: VenueManifest = {
   venueId: "gemini-predictions",
   displayName: "Gemini Prediction Markets",
-  adapterVersion: "0.1.0",
+  adapterVersion: "0.1.1",
   protocolIdentity: "prediction-markets-v1:2026-07-30",
   officialSources: [
     "https://developer.gemini.com/prediction-markets/prediction-markets",

--- a/packages/venue-kalshi/package.json
+++ b/packages/venue-kalshi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/venue-kalshi",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.ts" },

--- a/packages/venue-kalshi/src/index.ts
+++ b/packages/venue-kalshi/src/index.ts
@@ -139,7 +139,7 @@ export class KalshiDemoInertOrderGateway
 export const kalshiManifest: VenueManifest = {
   venueId: "kalshi",
   displayName: "Kalshi",
-  adapterVersion: "0.1.0",
+  adapterVersion: "0.1.1",
   protocolIdentity: "trade-api-v2:2026-07-31",
   officialSources: ["https://docs.kalshi.com/welcome"],
   mechanisms: ["centralized binary and multivariate event contracts"],

--- a/packages/venue-limitless/package.json
+++ b/packages/venue-limitless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/venue-limitless",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.ts" },

--- a/packages/venue-limitless/src/index.ts
+++ b/packages/venue-limitless/src/index.ts
@@ -68,7 +68,7 @@ function inferTick(prices: readonly bigint[]): bigint {
 export const limitlessManifest: VenueManifest = {
   venueId: "limitless",
   displayName: "Limitless",
-  adapterVersion: "0.1.0",
+  adapterVersion: "0.1.1",
   protocolIdentity: "markets-socket-io:2026-07-31",
   officialSources: [
     "https://docs.limitless.exchange/developers/websocket-events",

--- a/packages/venue-myriad/package.json
+++ b/packages/venue-myriad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/venue-myriad",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.ts" },

--- a/packages/venue-myriad/src/index.ts
+++ b/packages/venue-myriad/src/index.ts
@@ -40,7 +40,7 @@ const ResponseSchema = z.object({
 export const myriadManifest: VenueManifest = {
   venueId: "myriad",
   displayName: "Myriad Markets",
-  adapterVersion: "0.1.0",
+  adapterVersion: "0.1.1",
   protocolIdentity: "api-v2.0.4:2026-07-31",
   officialSources: [
     "https://docs.myriad.markets/builders/myriad-api-reference",

--- a/packages/venue-opinion/package.json
+++ b/packages/venue-opinion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/venue-opinion",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.ts" },

--- a/packages/venue-opinion/src/index.ts
+++ b/packages/venue-opinion/src/index.ts
@@ -54,7 +54,7 @@ export type OpinionOrderbookBestAsk = Readonly<{
 export const opinionManifest: VenueManifest = {
   venueId: "opinion",
   displayName: "Opinion",
-  adapterVersion: "0.1.0",
+  adapterVersion: "0.1.1",
   protocolIdentity: "openapi:2026-07-31",
   officialSources: [
     "https://docs.opinion.trade/developer-guide/opinion-open-api/overview",

--- a/packages/venue-polymarket-us/package.json
+++ b/packages/venue-polymarket-us/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/venue-polymarket-us",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.ts" },

--- a/packages/venue-polymarket-us/src/index.ts
+++ b/packages/venue-polymarket-us/src/index.ts
@@ -149,7 +149,7 @@ export type PolymarketUsBboObservation = Readonly<{
 export const polymarketUsManifest: VenueManifest = {
   venueId: "polymarket-us",
   displayName: "Polymarket US",
-  adapterVersion: "0.1.0",
+  adapterVersion: "0.1.1",
   protocolIdentity: "gateway-rest-v1:2026-08-01",
   officialSources: [
     "https://docs.polymarket.us/api-reference/introduction",

--- a/packages/venue-polymarket/package.json
+++ b/packages/venue-polymarket/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmh/venue-polymarket",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": { ".": "./src/index.ts" },

--- a/packages/venue-polymarket/src/index.ts
+++ b/packages/venue-polymarket/src/index.ts
@@ -64,7 +64,7 @@ const BookMessageSchema = z.object({
 export const polymarketManifest: VenueManifest = {
   venueId: "polymarket-global",
   displayName: "Polymarket Predictions",
-  adapterVersion: "0.1.0",
+  adapterVersion: "0.1.1",
   protocolIdentity: "gamma-rest+combo-rfq:2026-07-31",
   officialSources: ["https://docs.polymarket.com/"],
   mechanisms: ["Polygon conditional outcome-token CLOB", "Combo/RFQ"],

--- a/scripts/capture-public-fixtures.mjs
+++ b/scripts/capture-public-fixtures.mjs
@@ -142,7 +142,7 @@ async function capture(name) {
   const response = await fetch(definition.sourceUrl, {
     headers: {
       accept: "application/json",
-      "user-agent": "prediction-market-harness-fixture-capture/0.1.0",
+      "user-agent": "prediction-market-harness-fixture-capture/0.1.1",
     },
     redirect: "follow",
     signal: AbortSignal.timeout(30_000),

--- a/scripts/capture-public-stream-fixtures.mjs
+++ b/scripts/capture-public-stream-fixtures.mjs
@@ -34,7 +34,7 @@ function makeFrame(rawText, eventName, ordinal) {
 
 async function fetchJson(url) {
   const response = await fetch(url, {
-    headers: { "user-agent": "prediction-market-harness/0.1.0" },
+    headers: { "user-agent": "prediction-market-harness/0.1.1" },
   });
   if (!response.ok) {
     throw new Error(`${url} returned HTTP ${response.status}`);

--- a/scripts/studio-harness-smoke.test.mjs
+++ b/scripts/studio-harness-smoke.test.mjs
@@ -1,122 +1,428 @@
 import assert from "node:assert/strict";
+import { randomBytes } from "node:crypto";
 import { spawn } from "node:child_process";
-import { mkdtemp, rm } from "node:fs/promises";
-import { createServer } from "node:net";
+import { access, chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import http from "node:http";
+import { connect, createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+
+const repositoryRoot = new URL("..", import.meta.url);
+const surfaceHost = "oa-surface-0123456789abcdef01234567.localhost";
+
+async function manifestCommand() {
+  const manifest = JSON.parse(await readFile(
+    new URL("../harness.json", import.meta.url),
+    "utf8",
+  ));
+  return manifest.capabilities.studio.command;
+}
+
+async function listen(server, port = 0) {
+  if (server.__harnessSockets === undefined) {
+    server.__harnessSockets = new Set();
+    server.on("connection", (socket) => {
+      server.__harnessSockets.add(socket);
+      socket.once("close", () => server.__harnessSockets.delete(socket));
+    });
+  }
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  assert.ok(address !== null && typeof address === "object");
+  return address.port;
+}
+
+async function close(server) {
+  for (const socket of server.__harnessSockets ?? []) socket.destroy();
+  await new Promise((resolve, reject) => server.close((error) => {
+    if (error !== undefined) reject(error);
+    else resolve();
+  }));
+}
 
 async function allocateLoopbackPorts(count) {
   const servers = [];
   try {
     for (let index = 0; index < count; index += 1) {
       const server = createServer();
-      await new Promise((resolve, reject) => {
-        server.once("error", reject);
-        server.listen(0, "127.0.0.1", resolve);
-      });
+      await listen(server);
       servers.push(server);
     }
-    return servers.map((server) => {
-      const address = server.address();
-      assert.ok(address !== null && typeof address === "object");
-      return address.port;
-    });
+    return servers.map((server) => server.address().port);
   } finally {
-    await Promise.all(servers.map((server) =>
-      new Promise((resolve) => server.close(resolve))
-    ));
+    await Promise.all(servers.map(close));
   }
 }
 
-async function fetchUntilReady(url, deadline) {
+async function holdDefaultPortIfAvailable(port) {
+  const server = createServer();
+  try {
+    await listen(server, port);
+    return server;
+  } catch (error) {
+    if (error?.code === "EADDRINUSE") return undefined;
+    throw error;
+  }
+}
+
+function cleanEnvironment(overrides = {}) {
+  const environment = { ...process.env, ...overrides };
+  for (const name of [
+    "HARNESS_CAPABILITY",
+    "HARNESS_HOST",
+    "HARNESS_PORTS",
+    "HARNESS_NO_OPEN",
+    "OPENALICE_CAPABILITY",
+    "OPENALICE_CAPABILITY_HOST",
+    "OPENALICE_CAPABILITY_PORTS",
+    "OPENALICE_CAPABILITY_NO_OPEN",
+    "PMH_STUDIO_HOST",
+    "PMH_STUDIO_HTTP_PORT",
+    "PMH_STUDIO_CONTROL_PLANE_PORT",
+  ]) {
+    if (!(name in overrides)) delete environment[name];
+  }
+  return environment;
+}
+
+async function startCapability({ environment, extraArguments = [] }) {
+  const [executable, ...arguments_] = await manifestCommand();
+  const output = [];
+  const child = spawn(executable, [...arguments_, ...extraArguments], {
+    cwd: repositoryRoot,
+    env: environment,
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: process.platform !== "win32",
+  });
+  child.stdout.on("data", (chunk) => output.push(chunk.toString()));
+  child.stderr.on("data", (chunk) => output.push(chunk.toString()));
+  const exit = new Promise((resolve) => child.once("exit", (code, signal) => {
+    resolve({ code, signal });
+  }));
+  return { child, exit, output };
+}
+
+function request({ port, path = "/", host = "127.0.0.1", headers = {} }) {
+  return new Promise((resolve, reject) => {
+    const request_ = http.request({
+      hostname: "127.0.0.1",
+      port,
+      path,
+      headers: { host, ...headers },
+      timeout: 2_000,
+    }, (response) => {
+      const chunks = [];
+      response.on("data", (chunk) => chunks.push(chunk));
+      response.on("end", () => resolve({
+        status: response.statusCode,
+        headers: response.headers,
+        body: Buffer.concat(chunks).toString("utf8"),
+      }));
+    });
+    request_.once("timeout", () => request_.destroy(new Error("request timed out")));
+    request_.once("error", reject);
+    request_.end();
+  });
+}
+
+async function requestUntilReady(input, deadline) {
   let diagnostic = "no response";
   while (Date.now() < deadline) {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 2_000);
     try {
-      const response = await fetch(url, { signal: controller.signal });
-      if (response.ok) return response;
-      diagnostic = `HTTP ${response.status}: ${await response.text()}`;
+      const response = await request(input);
+      if (response.status >= 200 && response.status < 300) return response;
+      diagnostic = `HTTP ${response.status}: ${response.body}`;
     } catch (error) {
       diagnostic = error instanceof Error ? error.message : String(error);
-    } finally {
-      clearTimeout(timer);
     }
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
-  throw new Error(`timed out waiting for ${url}: ${diagnostic}`);
+  throw new Error(`timed out waiting for ${input.path}: ${diagnostic}`);
 }
 
-test("starts the complete Studio on exact OpenAlice loopback ports", {
+function openSse({ port, host }) {
+  return new Promise((resolve, reject) => {
+    const request_ = http.request({
+      hostname: "127.0.0.1",
+      port,
+      path: "/api/v1/events",
+      headers: { host, accept: "text/event-stream" },
+    });
+    request_.once("response", (response) => {
+      resolve({ response, close: () => {
+        response.destroy();
+        request_.destroy();
+      } });
+    });
+    request_.once("error", reject);
+    request_.end();
+  });
+}
+
+function openViteWebSocket({ port, host, token }) {
+  let socket;
+  const handshake = new Promise((resolve, reject) => {
+    socket = connect({ host: "127.0.0.1", port });
+    const key = randomBytes(16).toString("base64");
+    let response = "";
+    socket.once("connect", () => socket.write([
+      `GET /?token=${encodeURIComponent(token)} HTTP/1.1`,
+      `Host: ${host}`,
+      "Connection: Upgrade",
+      "Upgrade: websocket",
+      `Sec-WebSocket-Key: ${key}`,
+      "Sec-WebSocket-Version: 13",
+      "Sec-WebSocket-Protocol: vite-hmr",
+      `Origin: http://${host}`,
+      "",
+      "",
+    ].join("\r\n")));
+    socket.on("data", (chunk) => {
+      response += chunk.toString("latin1");
+      if (!response.includes("\r\n\r\n")) return;
+      if (!response.startsWith("HTTP/1.1 101")) {
+        socket.destroy();
+        reject(new Error(`unexpected WebSocket response: ${response}`));
+        return;
+      }
+      resolve({ socket, response });
+    });
+    socket.once("error", reject);
+    socket.once("close", () => reject(new Error(
+      `WebSocket closed before upgrade: ${response}`,
+    )));
+  });
+  let timer;
+  return Promise.race([
+    handshake,
+    new Promise((_, reject) => {
+      timer = setTimeout(() => {
+        socket?.destroy();
+        reject(new Error("WebSocket upgrade timed out"));
+      }, 3_000);
+    }),
+  ]).finally(() => clearTimeout(timer));
+}
+
+async function waitForExit(launch, timeout = 10_000) {
+  let timer;
+  try {
+    return await Promise.race([
+      launch.exit,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(
+          `capability did not exit:\n${launch.output.join("")}`,
+        )), timeout);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function stopCapability(launch) {
+  if (launch.child.exitCode === null && launch.child.signalCode === null) {
+    launch.child.kill("SIGTERM");
+  }
+  try {
+    await waitForExit(launch);
+  } catch (error) {
+    if (process.platform !== "win32" && launch.child.pid !== undefined) {
+      try { process.kill(-launch.child.pid, "SIGKILL"); } catch {}
+    } else {
+      launch.child.kill("SIGKILL");
+    }
+    throw error;
+  }
+}
+
+async function assertPortReleased(port) {
+  const deadline = Date.now() + 10_000;
+  let diagnostic;
+  while (Date.now() < deadline) {
+    const probe = createServer();
+    try {
+      await listen(probe, port);
+      await close(probe);
+      return;
+    } catch (error) {
+      diagnostic = error;
+      if (probe.listening) await close(probe);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+  throw new Error(`port ${port} was not released: ${diagnostic}`);
+}
+
+test("standalone manifest command remains runnable without HARNESS variables", {
   timeout: 90_000,
 }, async () => {
-  const pnpmExecutable = process.env.npm_execpath ?? "pnpm";
-  const packageManagerIsScript = /\.(?:c?js|mjs)$/u.test(pnpmExecutable);
   const [httpPort, controlPlanePort] = await allocateLoopbackPorts(2);
-  const directory = await mkdtemp(join(tmpdir(), "auto-prediction-harness-"));
-  const output = [];
-  const child = spawn(
-    packageManagerIsScript ? process.execPath : pnpmExecutable,
-    packageManagerIsScript ? [pnpmExecutable, "studio"] : ["studio"],
-    {
-    cwd: new URL("..", import.meta.url),
-    env: {
-      ...process.env,
-      OPENALICE_CAPABILITY: "studio",
-      OPENALICE_CAPABILITY_HOST: "127.0.0.1",
-      OPENALICE_CAPABILITY_PORTS: JSON.stringify({ http: httpPort, controlPlane: controlPlanePort }),
-      OPENALICE_CAPABILITY_NO_OPEN: "1",
+  const directory = await mkdtemp(join(tmpdir(), "auto-prediction-standalone-"));
+  const launch = await startCapability({
+    environment: cleanEnvironment({
       PMH_STATE_DB: join(directory, "control-plane.sqlite"),
-    },
-      stdio: ["ignore", "pipe", "pipe"],
-    },
-  );
-  child.stdout.on("data", (chunk) => output.push(chunk.toString()));
-  child.stderr.on("data", (chunk) => output.push(chunk.toString()));
-  const exit = new Promise((resolve) => child.once("exit", (code, signal) =>
-    resolve({ code, signal })
-  ));
+    }),
+    extraArguments: [
+      "--",
+      "--host", "127.0.0.1",
+      "--port", String(httpPort),
+      "--control-plane-port", String(controlPlanePort),
+    ],
+  });
+  try {
+    const health = await requestUntilReady({ port: httpPort, path: "/health" }, Date.now() + 60_000);
+    assert.equal(JSON.parse(health.body).ok, true);
+    assert.equal((await request({ port: controlPlanePort, path: "/health" })).status, 200);
+  } finally {
+    await stopCapability(launch);
+    await Promise.all([assertPortReleased(httpPort), assertPortReleased(controlPlanePort)]);
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("managed manifest command serves the complete same-origin surface on exact ports", {
+  timeout: 90_000,
+}, async () => {
+  const [httpPort, controlPlanePort] = await allocateLoopbackPorts(2);
+  const defaultHolders = (await Promise.all([
+    holdDefaultPortIfAvailable(5_173),
+    holdDefaultPortIfAvailable(4_100),
+  ])).filter(Boolean);
+  const directory = await mkdtemp(join(tmpdir(), "auto-prediction-harness-"));
+  const opener = join(directory, "browser-opener");
+  const openerSentinel = join(directory, "browser-opened");
+  await writeFile(opener, `#!/bin/sh\ntouch "${openerSentinel}"\n`, "utf8");
+  await chmod(opener, 0o755);
+  const launch = await startCapability({
+    environment: cleanEnvironment({
+      HARNESS_CAPABILITY: "studio",
+      HARNESS_HOST: "127.0.0.1",
+      HARNESS_PORTS: JSON.stringify({ http: httpPort, controlPlane: controlPlanePort }),
+      HARNESS_NO_OPEN: "1",
+      BROWSER: opener,
+      PMH_STATE_DB: join(directory, "control-plane.sqlite"),
+    }),
+  });
 
   try {
-    const entry = `http://127.0.0.1:${httpPort}`;
     const deadline = Date.now() + 60_000;
-    const health = await fetchUntilReady(`${entry}/health`, deadline);
-    assert.equal((await health.json()).ok, true);
+    const health = await requestUntilReady({
+      port: httpPort,
+      path: "/health",
+      host: surfaceHost,
+    }, deadline);
+    assert.equal(JSON.parse(health.body).ok, true);
 
-    const readiness = await fetchUntilReady(`${entry}/api/v1/readiness`, deadline);
-    assert.equal((await readiness.json()).schemaVersion, "pmh.startup-readiness.v1");
+    const controlPlaneHealth = await request({ port: controlPlanePort, path: "/health" });
+    assert.equal(controlPlaneHealth.status, 200);
 
-    const html = await fetchUntilReady(entry, deadline);
-    assert.match(await html.text(), /<!doctype html>/iu);
+    const html = await request({ port: httpPort, host: surfaceHost });
+    assert.equal(html.status, 200);
+    assert.match(html.body, /<!doctype html>/iu);
+    assert.equal(html.headers["x-frame-options"], undefined);
+    assert.doesNotMatch(html.headers["content-security-policy"] ?? "", /frame-ancestors\s+'none'/iu);
+    const assetPath = html.body.match(/(?:src|href)="(\/[^"?#]+)/u)?.[1];
+    assert.ok(assetPath, "Studio HTML must reference a root-relative asset");
+    const asset = await request({ port: httpPort, path: assetPath, host: surfaceHost });
+    assert.equal(asset.status, 200);
+    assert.doesNotMatch(asset.body, new RegExp(`127\\.0\\.0\\.1:${httpPort}`, "u"));
+    assert.doesNotMatch(asset.body, new RegExp(`127\\.0\\.0\\.1:${controlPlanePort}`, "u"));
+    assert.match(asset.body, /const serverHost = importMetaUrl\.host;/u);
+    assert.match(asset.body, /const directSocketHost = socketHost;/u);
+    const webSocketToken = asset.body.match(/const wsToken = "([^"]+)"/u)?.[1];
+    assert.ok(webSocketToken, "Vite client must carry its HMR WebSocket token");
 
-    const controller = new AbortController();
-    const events = await fetch(`${entry}/api/v1/events`, {
-      headers: { accept: "text/event-stream" },
-      signal: controller.signal,
+    const readiness = await request({
+      port: httpPort,
+      path: "/api/v1/readiness",
+      host: surfaceHost,
     });
-    assert.equal(events.status, 200);
-    assert.match(events.headers.get("content-type") ?? "", /^text\/event-stream/u);
-    controller.abort();
+    assert.equal(readiness.status, 200);
+    assert.equal(JSON.parse(readiness.body).schemaVersion, "pmh.startup-readiness.v1");
 
-    assert.match(output.join(""), new RegExp(`127\\.0\\.0\\.1:${httpPort}`));
-    assert.doesNotMatch(output.join(""), /Local:\s+http:\/\/127\.0\.0\.1:517[3-9]/u);
+    const sse = await openSse({ port: httpPort, host: surfaceHost });
+    assert.equal(sse.response.statusCode, 200);
+    assert.match(sse.response.headers["content-type"] ?? "", /^text\/event-stream/u);
+    sse.close();
+
+    const websocket = await openViteWebSocket({
+      port: httpPort,
+      host: surfaceHost,
+      token: webSocketToken,
+    });
+    assert.match(websocket.response, /Sec-WebSocket-Protocol: vite-hmr/iu);
+    websocket.socket.destroy();
+
+    await assert.rejects(access(openerSentinel));
+    const output = launch.output.join("");
+    assert.match(output, new RegExp(`127\\.0\\.0\\.1:${httpPort}`));
+    assert.doesNotMatch(output, /Local:\s+http:\/\/127\.0\.0\.1:517[3-9]/u);
   } finally {
-    if (child.exitCode === null && child.signalCode === null) child.kill("SIGTERM");
-    let shutdownTimer;
-    try {
-      await Promise.race([
-        exit,
-        new Promise((_, reject) => {
-          shutdownTimer = setTimeout(
-            () => reject(new Error(`Studio did not stop cleanly:\n${output.join("")}`)),
-            10_000,
-          );
-        }),
-      ]);
-    } finally {
-      clearTimeout(shutdownTimer);
-    }
+    await Promise.all(defaultHolders.map(close));
+    await stopCapability(launch);
+    await Promise.all([assertPortReleased(httpPort), assertPortReleased(controlPlanePort)]);
     await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("managed launch rejects conflicting explicit ports before spawning children", {
+  timeout: 20_000,
+}, async () => {
+  const [httpPort, controlPlanePort, conflictingPort] = await allocateLoopbackPorts(3);
+  const launch = await startCapability({
+    environment: cleanEnvironment({
+      HARNESS_CAPABILITY: "studio",
+      HARNESS_HOST: "127.0.0.1",
+      HARNESS_PORTS: JSON.stringify({ http: httpPort, controlPlane: controlPlanePort }),
+      HARNESS_NO_OPEN: "1",
+    }),
+    extraArguments: ["--", "--port", String(conflictingPort)],
+  });
+  const result = await waitForExit(launch, 10_000);
+  assert.notEqual(result.code, 0);
+  assert.match(launch.output.join(""), /conflicts with Harness injection/u);
+  await Promise.all([assertPortReleased(httpPort), assertPortReleased(controlPlanePort)]);
+});
+
+test("managed launch fails quickly when either injected port is occupied", {
+  timeout: 45_000,
+}, async (context) => {
+  for (const occupiedName of ["http", "controlPlane"]) {
+    await context.test(occupiedName, async () => {
+      const occupant = createServer();
+      const occupiedPort = await listen(occupant);
+      const [otherPort] = await allocateLoopbackPorts(1);
+      const ports = occupiedName === "http"
+        ? { http: occupiedPort, controlPlane: otherPort }
+        : { http: otherPort, controlPlane: occupiedPort };
+      const directory = await mkdtemp(join(tmpdir(), "auto-prediction-occupied-"));
+      const launch = await startCapability({
+        environment: cleanEnvironment({
+          HARNESS_CAPABILITY: "studio",
+          HARNESS_HOST: "127.0.0.1",
+          HARNESS_PORTS: JSON.stringify(ports),
+          HARNESS_NO_OPEN: "1",
+          PMH_STATE_DB: join(directory, "control-plane.sqlite"),
+        }),
+      });
+      try {
+        const result = await waitForExit(launch, 10_000);
+        assert.notEqual(result.code, 0);
+        assert.match(launch.output.join(""), /port .* is already in use/u);
+        assert.doesNotMatch(launch.output.join(""), /Local:\s+http:/u);
+      } finally {
+        if (launch.child.exitCode === null && launch.child.signalCode === null) {
+          await stopCapability(launch);
+        }
+        await close(occupant);
+        await Promise.all([assertPortReleased(ports.http), assertPortReleased(ports.controlPlane)]);
+        await rm(directory, { recursive: true, force: true });
+      }
+    });
   }
 });

--- a/scripts/studio-runtime-config.d.mts
+++ b/scripts/studio-runtime-config.d.mts
@@ -7,6 +7,22 @@ export type StudioRuntimeConfig = Readonly<{
   openBrowser: false;
 }>;
 
+export type StudioCliOverrides = Readonly<{
+  host?: string;
+  httpPort?: number;
+  controlPlanePort?: number;
+}>;
+
+export function parseStudioCliOverrides(
+  arguments_?: readonly string[],
+): StudioCliOverrides;
+
 export function resolveStudioRuntimeConfig(
   environment?: Readonly<Record<string, string | undefined>>,
+  arguments_?: readonly string[],
 ): StudioRuntimeConfig;
+
+export function studioChildEnvironment(
+  runtime: StudioRuntimeConfig,
+  environment?: Readonly<Record<string, string | undefined>>,
+): Record<string, string | undefined>;

--- a/scripts/studio-runtime-config.mjs
+++ b/scripts/studio-runtime-config.mjs
@@ -1,62 +1,147 @@
 const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
+const DEFAULT_HTTP_PORT = 5_173;
+const DEFAULT_CONTROL_PLANE_PORT = 4_100;
 
-function managedPort(value, name) {
-  if (!Number.isInteger(value) || value < 1 || value > 65_535) {
-    throw new Error(
-      `OPENALICE_CAPABILITY_PORTS.${name} must be an integer from 1 to 65535`,
-    );
+function port(value, name) {
+  const parsed = typeof value === "string" && value.trim() !== ""
+    ? Number(value)
+    : value;
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65_535) {
+    throw new Error(`${name} must be an integer from 1 to 65535`);
+  }
+  return parsed;
+}
+
+function loopbackHost(value, name) {
+  if (typeof value !== "string" || !LOOPBACK_HOSTS.has(value)) {
+    throw new Error(`${name} must be 127.0.0.1, ::1, or localhost`);
   }
   return value;
 }
 
-export function resolveStudioRuntimeConfig(environment = process.env) {
-  const managed = environment.OPENALICE_CAPABILITY === "studio";
-  if (!managed) return Object.freeze({
-    managed,
-    host: "127.0.0.1",
-    httpPort: 5_173,
-    controlPlanePort: 4_100,
-    strictHttpPort: managed,
-    openBrowser: false,
-  });
-
-  const host = environment.OPENALICE_CAPABILITY_HOST;
-  if (typeof host !== "string" || !LOOPBACK_HOSTS.has(host)) {
-    throw new Error(
-      "OPENALICE_CAPABILITY_HOST must be 127.0.0.1, ::1, or localhost in studio mode",
-    );
+function readOptionValue(arguments_, index, name) {
+  const argument = arguments_[index];
+  const prefix = `${name}=`;
+  if (argument.startsWith(prefix)) {
+    return { value: argument.slice(prefix.length), consumed: 0 };
   }
-  const encodedPorts = environment.OPENALICE_CAPABILITY_PORTS;
+  if (argument !== name) return undefined;
+  const value = arguments_[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+  return { value, consumed: 1 };
+}
+
+export function parseStudioCliOverrides(arguments_ = []) {
+  const overrides = {};
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index];
+    if (argument === "--") continue;
+    const host = readOptionValue(arguments_, index, "--host");
+    if (host !== undefined) {
+      overrides.host = loopbackHost(host.value, "--host");
+      index += host.consumed;
+      continue;
+    }
+    const http = readOptionValue(arguments_, index, "--port")
+      ?? readOptionValue(arguments_, index, "--http-port");
+    if (http !== undefined) {
+      overrides.httpPort = port(http.value, argument.split("=")[0]);
+      index += http.consumed;
+      continue;
+    }
+    const controlPlane = readOptionValue(arguments_, index, "--control-plane-port");
+    if (controlPlane !== undefined) {
+      overrides.controlPlanePort = port(controlPlane.value, "--control-plane-port");
+      index += controlPlane.consumed;
+    }
+  }
+  return Object.freeze(overrides);
+}
+
+function assertNoConflict(name, explicit, injected) {
+  if (explicit !== undefined && explicit !== injected) {
+    throw new Error(`${name}=${explicit} conflicts with Harness injection ${injected}`);
+  }
+}
+
+export function resolveStudioRuntimeConfig(
+  environment = process.env,
+  arguments_ = [],
+) {
+  const explicit = parseStudioCliOverrides(arguments_);
+  const managed = environment.HARNESS_CAPABILITY === "studio";
+  if (!managed) {
+    const host = explicit.host
+      ?? loopbackHost(environment.PMH_STUDIO_HOST ?? "127.0.0.1", "PMH_STUDIO_HOST");
+    const httpPort = explicit.httpPort
+      ?? port(environment.PMH_STUDIO_HTTP_PORT ?? DEFAULT_HTTP_PORT, "PMH_STUDIO_HTTP_PORT");
+    const controlPlanePort = explicit.controlPlanePort
+      ?? port(
+        environment.PMH_STUDIO_CONTROL_PLANE_PORT ?? DEFAULT_CONTROL_PLANE_PORT,
+        "PMH_STUDIO_CONTROL_PLANE_PORT",
+      );
+    if (httpPort === controlPlanePort) {
+      throw new Error("Studio http and controlPlane ports must be different");
+    }
+    return Object.freeze({
+      managed,
+      host,
+      httpPort,
+      controlPlanePort,
+      strictHttpPort: false,
+      openBrowser: false,
+    });
+  }
+
+  const host = loopbackHost(environment.HARNESS_HOST, "HARNESS_HOST");
+  const encodedPorts = environment.HARNESS_PORTS;
   if (typeof encodedPorts !== "string" || encodedPorts.trim() === "") {
-    throw new Error("OPENALICE_CAPABILITY_PORTS is required in studio mode");
+    throw new Error("HARNESS_PORTS is required in studio mode");
   }
   let decoded;
   try {
     decoded = JSON.parse(encodedPorts);
   } catch {
-    throw new Error("OPENALICE_CAPABILITY_PORTS must be valid JSON");
+    throw new Error("HARNESS_PORTS must be valid JSON");
   }
   if (decoded === null || typeof decoded !== "object" || Array.isArray(decoded)) {
-    throw new Error("OPENALICE_CAPABILITY_PORTS must be a JSON object");
+    throw new Error("HARNESS_PORTS must be a JSON object");
   }
   const keys = Object.keys(decoded).sort();
   if (keys.length !== 2 || keys[0] !== "controlPlane" || keys[1] !== "http") {
-    throw new Error(
-      "OPENALICE_CAPABILITY_PORTS must contain exactly http and controlPlane",
-    );
+    throw new Error("HARNESS_PORTS must contain exactly http and controlPlane");
   }
-  const httpPort = managedPort(decoded.http, "http");
-  const controlPlanePort = managedPort(decoded.controlPlane, "controlPlane");
+  const httpPort = port(decoded.http, "HARNESS_PORTS.http");
+  const controlPlanePort = port(decoded.controlPlane, "HARNESS_PORTS.controlPlane");
   if (httpPort === controlPlanePort) {
-    throw new Error("OpenAlice studio http and controlPlane ports must be different");
+    throw new Error("Harness studio http and controlPlane ports must be different");
   }
+
+  assertNoConflict("--host", explicit.host, host);
+  assertNoConflict("--port", explicit.httpPort, httpPort);
+  assertNoConflict(
+    "--control-plane-port",
+    explicit.controlPlanePort,
+    controlPlanePort,
+  );
 
   return Object.freeze({
     managed,
     host,
     httpPort,
     controlPlanePort,
-    strictHttpPort: managed,
+    strictHttpPort: true,
     openBrowser: false,
   });
+}
+
+export function studioChildEnvironment(runtime, environment = process.env) {
+  return {
+    ...environment,
+    PMH_STUDIO_HOST: runtime.host,
+    PMH_STUDIO_HTTP_PORT: String(runtime.httpPort),
+    PMH_STUDIO_CONTROL_PLANE_PORT: String(runtime.controlPlanePort),
+  };
 }

--- a/scripts/studio-runtime-config.test.mjs
+++ b/scripts/studio-runtime-config.test.mjs
@@ -2,16 +2,32 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
-import { resolveStudioRuntimeConfig } from "./studio-runtime-config.mjs";
+import {
+  parseStudioCliOverrides,
+  resolveStudioRuntimeConfig,
+  studioChildEnvironment,
+} from "./studio-runtime-config.mjs";
 
-test("publishes the OpenAlice Harness Studio capability manifest", async () => {
+const managedEnvironment = Object.freeze({
+  HARNESS_CAPABILITY: "studio",
+  HARNESS_HOST: "127.0.0.1",
+  HARNESS_PORTS: '{"http":49321,"controlPlane":49322}',
+  HARNESS_NO_OPEN: "1",
+});
+
+test("publishes the generic Harness Studio capability manifest", async () => {
   const manifest = JSON.parse(await readFile(
     new URL("../harness.json", import.meta.url),
     "utf8",
   ));
+  const productPackage = JSON.parse(await readFile(
+    new URL("../package.json", import.meta.url),
+    "utf8",
+  ));
+  assert.equal(manifest.version, productPackage.version);
   assert.deepEqual(manifest, {
     manifestVersion: 1,
-    version: "0.1.0",
+    version: "0.1.1",
     capabilities: {
       studio: {
         command: ["pnpm", "studio"],
@@ -23,13 +39,8 @@ test("publishes the OpenAlice Harness Studio capability manifest", async () => {
   });
 });
 
-test("parses exact managed Studio ports", () => {
-  assert.deepEqual(resolveStudioRuntimeConfig({
-    OPENALICE_CAPABILITY: "studio",
-    OPENALICE_CAPABILITY_HOST: "127.0.0.1",
-    OPENALICE_CAPABILITY_PORTS: '{"http":49321,"controlPlane":49322}',
-    OPENALICE_CAPABILITY_NO_OPEN: "1",
-  }), {
+test("parses exact generic Harness ports", () => {
+  assert.deepEqual(resolveStudioRuntimeConfig(managedEnvironment), {
     managed: true,
     host: "127.0.0.1",
     httpPort: 49_321,
@@ -39,7 +50,7 @@ test("parses exact managed Studio ports", () => {
   });
 });
 
-test("preserves independent Studio defaults", () => {
+test("preserves standalone defaults and supports explicit standalone ports", () => {
   assert.deepEqual(resolveStudioRuntimeConfig({}), {
     managed: false,
     host: "127.0.0.1",
@@ -48,46 +59,115 @@ test("preserves independent Studio defaults", () => {
     strictHttpPort: false,
     openBrowser: false,
   });
+  assert.deepEqual(resolveStudioRuntimeConfig({}, [
+    "--host=localhost",
+    "--port", "15173",
+    "--control-plane-port=14100",
+  ]), {
+    managed: false,
+    host: "localhost",
+    httpPort: 15_173,
+    controlPlanePort: 14_100,
+    strictHttpPort: false,
+    openBrowser: false,
+  });
+});
+
+test("only the generic studio capability activates managed mode", () => {
   assert.equal(resolveStudioRuntimeConfig({
-    OPENALICE_CAPABILITY: "another-capability",
+    HARNESS_CAPABILITY: "another-capability",
   }).managed, false);
+  assert.equal(resolveStudioRuntimeConfig({
+    OPENALICE_CAPABILITY: "studio",
+    OPENALICE_CAPABILITY_HOST: "127.0.0.1",
+    OPENALICE_CAPABILITY_PORTS: '{"http":49321,"controlPlane":49322}',
+  }).managed, false);
+});
+
+test("accepts equal managed CLI values and rejects conflicts", () => {
+  assert.equal(resolveStudioRuntimeConfig(managedEnvironment, [
+    "--host", "127.0.0.1",
+    "--http-port=49321",
+    "--control-plane-port", "49322",
+  ]).managed, true);
+  assert.throws(
+    () => resolveStudioRuntimeConfig(managedEnvironment, ["--port", "49323"]),
+    /conflicts with Harness injection/,
+  );
+  assert.throws(
+    () => resolveStudioRuntimeConfig(managedEnvironment, ["--host=localhost"]),
+    /conflicts with Harness injection/,
+  );
+});
+
+test("propagates one resolved config to standalone children", () => {
+  const environment = studioChildEnvironment({
+    managed: false,
+    host: "127.0.0.1",
+    httpPort: 15_173,
+    controlPlanePort: 14_100,
+    strictHttpPort: false,
+    openBrowser: false,
+  }, { PATH: "/bin" });
+  assert.deepEqual(resolveStudioRuntimeConfig(environment), {
+    managed: false,
+    host: "127.0.0.1",
+    httpPort: 15_173,
+    controlPlanePort: 14_100,
+    strictHttpPort: false,
+    openBrowser: false,
+  });
+  assert.equal(environment.PATH, "/bin");
+});
+
+test("parses supported Studio CLI spellings", () => {
+  assert.deepEqual(parseStudioCliOverrides([
+    "--",
+    "--host", "127.0.0.1",
+    "--port=15173",
+    "--control-plane-port", "14100",
+  ]), {
+    host: "127.0.0.1",
+    httpPort: 15_173,
+    controlPlanePort: 14_100,
+  });
 });
 
 for (const [name, environment, diagnostic] of [
   ["missing ports", {
-    OPENALICE_CAPABILITY: "studio",
-    OPENALICE_CAPABILITY_HOST: "127.0.0.1",
-  }, /PORTS is required/],
+    HARNESS_CAPABILITY: "studio",
+    HARNESS_HOST: "127.0.0.1",
+  }, /HARNESS_PORTS is required/],
   ["invalid JSON", {
-    OPENALICE_CAPABILITY: "studio",
-    OPENALICE_CAPABILITY_HOST: "127.0.0.1",
-    OPENALICE_CAPABILITY_PORTS: "not-json",
+    HARNESS_CAPABILITY: "studio",
+    HARNESS_HOST: "127.0.0.1",
+    HARNESS_PORTS: "not-json",
   }, /valid JSON/],
   ["missing named port", {
-    OPENALICE_CAPABILITY: "studio",
-    OPENALICE_CAPABILITY_HOST: "127.0.0.1",
-    OPENALICE_CAPABILITY_PORTS: '{"http":49321}',
+    HARNESS_CAPABILITY: "studio",
+    HARNESS_HOST: "127.0.0.1",
+    HARNESS_PORTS: '{"http":49321}',
   }, /exactly http and controlPlane/],
   ["non-integer port", {
-    OPENALICE_CAPABILITY: "studio",
-    OPENALICE_CAPABILITY_HOST: "127.0.0.1",
-    OPENALICE_CAPABILITY_PORTS: '{"http":49321.5,"controlPlane":49322}',
+    HARNESS_CAPABILITY: "studio",
+    HARNESS_HOST: "127.0.0.1",
+    HARNESS_PORTS: '{"http":49321.5,"controlPlane":49322}',
   }, /http must be an integer/],
   ["out-of-range port", {
-    OPENALICE_CAPABILITY: "studio",
-    OPENALICE_CAPABILITY_HOST: "127.0.0.1",
-    OPENALICE_CAPABILITY_PORTS: '{"http":0,"controlPlane":49322}',
+    HARNESS_CAPABILITY: "studio",
+    HARNESS_HOST: "127.0.0.1",
+    HARNESS_PORTS: '{"http":0,"controlPlane":49322}',
   }, /http must be an integer/],
   ["duplicate ports", {
-    OPENALICE_CAPABILITY: "studio",
-    OPENALICE_CAPABILITY_HOST: "127.0.0.1",
-    OPENALICE_CAPABILITY_PORTS: '{"http":49321,"controlPlane":49321}',
+    HARNESS_CAPABILITY: "studio",
+    HARNESS_HOST: "127.0.0.1",
+    HARNESS_PORTS: '{"http":49321,"controlPlane":49321}',
   }, /must be different/],
   ["remote host", {
-    OPENALICE_CAPABILITY: "studio",
-    OPENALICE_CAPABILITY_HOST: "0.0.0.0",
-    OPENALICE_CAPABILITY_PORTS: '{"http":49321,"controlPlane":49322}',
-  }, /must be 127\.0\.0\.1/],
+    HARNESS_CAPABILITY: "studio",
+    HARNESS_HOST: "0.0.0.0",
+    HARNESS_PORTS: '{"http":49321,"controlPlane":49322}',
+  }, /HARNESS_HOST must be 127\.0\.0\.1/],
 ]) {
   test(`fails closed for ${name}`, () => {
     assert.throws(() => resolveStudioRuntimeConfig(environment), diagnostic);

--- a/scripts/studio-supervisor.test.mjs
+++ b/scripts/studio-supervisor.test.mjs
@@ -77,7 +77,7 @@ test("rejects before either child starts when port 4100 is occupied", async () =
   await new Promise((resolveClose) => occupant.close(resolveClose));
 });
 
-test("preflights both exact ports only in OpenAlice managed mode", async () => {
+test("preflights both exact ports only in Harness managed mode", async () => {
   const calls = [];
   const checkPort = async (input) => calls.push(input);
   await assertStudioPortsAvailable({
@@ -137,13 +137,13 @@ test("runs the control plane without a watcher that can hide startup failure", (
       calls.push(args);
       return fakeChild();
     },
-    environment: { OPENALICE_CAPABILITY: "studio" },
+    environment: { HARNESS_CAPABILITY: "studio" },
   });
 
   assert.deepEqual(calls.map(([executable, args]) => [executable, args]), [
     ["/node", ["/pnpm.cjs", "--filter", "@pmh/control-plane", "exec", "tsx", "src/main.ts"]],
     ["/node", ["/pnpm.cjs", "--filter", "@pmh/studio", "dev"]],
   ]);
-  assert.equal(calls[0][2].env.OPENALICE_CAPABILITY, "studio");
-  assert.equal(calls[1][2].env.OPENALICE_CAPABILITY, "studio");
+  assert.equal(calls[0][2].env.HARNESS_CAPABILITY, "studio");
+  assert.equal(calls[1][2].env.HARNESS_CAPABILITY, "studio");
 });

--- a/scripts/studio.mjs
+++ b/scripts/studio.mjs
@@ -4,12 +4,17 @@ import {
   stopChild,
   superviseStudio,
 } from "./studio-supervisor.mjs";
-import { resolveStudioRuntimeConfig } from "./studio-runtime-config.mjs";
+import {
+  resolveStudioRuntimeConfig,
+  studioChildEnvironment,
+} from "./studio-runtime-config.mjs";
 
 async function main() {
-  const runtime = resolveStudioRuntimeConfig();
+  const runtime = resolveStudioRuntimeConfig(process.env, process.argv.slice(2));
   await assertStudioPortsAvailable(runtime);
-  const children = startStudioChildren({ environment: process.env });
+  const children = startStudioChildren({
+    environment: studioChildEnvironment(runtime),
+  });
   let shuttingDown = false;
 
   for (const signal of ["SIGINT", "SIGTERM"]) {


### PR DESCRIPTION
## Summary

- replace the vendor-specific managed launch environment with the generic `HARNESS_*` v1 contract
- preserve standalone defaults while adding bounded loopback CLI overrides and managed conflict rejection
- allow restricted `.localhost` Surface Host identities without `allowedHosts: true`
- keep HTML, assets, API, SSE, and HMR WebSocket current-origin; remove Vite internal-bind fallback addresses from browser code
- retain the foreground supervisor lifecycle and fail closed on invalid or occupied injected ports
- publish the coherent repository version `0.1.1`

## Real-process acceptance

- standalone manifest command with no `HARNESS_*`
- random injected `http` and `controlPlane` ports, readiness only after `/health` 2xx
- exact listener binding with standalone defaults held unavailable
- `oa-surface-<24 hex>.localhost` root, asset, API, SSE, and token-authenticated Vite HMR WebSocket
- no browser opener when `HARNESS_NO_OPEN=1`
- conflicting CLI and occupied injected ports fail before child startup
- SIGTERM releases the command, descendants, and both injected ports

## Verification

- `pnpm check`
- `pnpm test`
- `pnpm studio:build`
- browser-source fixed-origin scan
- `git diff --check`

## Reproduce

`env HARNESS_CAPABILITY=studio HARNESS_HOST=127.0.0.1 HARNESS_PORTS='{"http":49321,"controlPlane":49322}' HARNESS_NO_OPEN=1 pnpm studio`